### PR TITLE
perf(search): rewrite search_photos via findPhotos

### DIFF
--- a/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
@@ -5,81 +5,65 @@ local logger = LrLogger('LightroomMCP')
 
 local SearchHandler = {}
 
+local function buildSearchDesc(args)
+    local desc = { combine = "intersect" }
+
+    if args.filename then
+        table.insert(desc, { criteria = "filename", operation = "any", value = args.filename })
+    end
+
+    if args.rating then
+        table.insert(desc, { criteria = "rating", operation = "==", value = args.rating })
+    end
+
+    if args.keywords and #args.keywords > 0 then
+        for _, kw in ipairs(args.keywords) do
+            table.insert(desc, { criteria = "keywords", operation = "all", value = kw })
+        end
+    end
+
+    if args.start_date and args.end_date then
+        table.insert(desc, {
+            criteria = "captureTime",
+            operation = "inRange",
+            value = args.start_date,
+            value2 = args.end_date,
+        })
+    elseif args.start_date then
+        table.insert(desc, { criteria = "captureTime", operation = ">=", value = args.start_date })
+    elseif args.end_date then
+        table.insert(desc, { criteria = "captureTime", operation = "<=", value = args.end_date })
+    end
+
+    return desc
+end
+
+local function buildResult(photo)
+    return {
+        id = photo.localIdentifier,
+        path = photo:getRawMetadata('path'),
+        filename = photo:getFormattedMetadata('fileName'),
+        rating = photo:getRawMetadata('rating'),
+        dateTimeOriginal = photo:getFormattedMetadata('dateTimeOriginal'),
+    }
+end
+
 function SearchHandler.searchPhotos(args)
     local catalog = LrApplication.activeCatalog()
     local results = {}
+    local searchDesc = buildSearchDesc(args)
+    local hasFilters = #searchDesc > 0
 
     catalog:withReadAccessDo(function()
-        local allPhotos = catalog:getAllPhotos()
+        local matches
+        if hasFilters then
+            matches = catalog:findPhotos{ searchDesc = searchDesc }
+        else
+            matches = catalog:getAllPhotos()
+        end
 
-        for _, photo in ipairs(allPhotos) do
-            local match = true
-
-            -- Filter by filename
-            if args.filename and match then
-                local fileName = photo:getFormattedMetadata('fileName')
-                if not fileName or not fileName:lower():find(args.filename:lower(), 1, true) then
-                    match = false
-                end
-            end
-
-            -- Filter by rating
-            if args.rating and match then
-                local rating = photo:getRawMetadata('rating')
-                if rating ~= args.rating then
-                    match = false
-                end
-            end
-
-            -- Filter by keywords
-            if args.keywords and #args.keywords > 0 and match then
-                local photoKeywords = photo:getRawMetadata('keywords')
-                local keywordNames = {}
-                if photoKeywords then
-                    for _, kw in ipairs(photoKeywords) do
-                        table.insert(keywordNames, kw:getName())
-                    end
-                end
-
-                for _, searchKw in ipairs(args.keywords) do
-                    local found = false
-                    for _, photoKw in ipairs(keywordNames) do
-                        if photoKw:lower() == searchKw:lower() then
-                            found = true
-                            break
-                        end
-                    end
-                    if not found then
-                        match = false
-                        break
-                    end
-                end
-            end
-
-            -- Filter by date range
-            if args.start_date and match then
-                local captureTime = photo:getRawMetadata('dateTimeOriginal')
-                if captureTime and captureTime < args.start_date then
-                    match = false
-                end
-            end
-
-            if args.end_date and match then
-                local captureTime = photo:getRawMetadata('dateTimeOriginal')
-                if captureTime and captureTime > args.end_date then
-                    match = false
-                end
-            end
-
-            if match then
-                table.insert(results, {
-                    id = photo.localIdentifier,
-                    path = photo:getRawMetadata('path'),
-                    filename = photo:getFormattedMetadata('fileName'),
-                    rating = photo:getRawMetadata('rating'),
-                    dateTimeOriginal = photo:getFormattedMetadata('dateTimeOriginal'),
-                })
-            end
+        for _, photo in ipairs(matches) do
+            table.insert(results, buildResult(photo))
         end
     end)
 
@@ -87,7 +71,7 @@ function SearchHandler.searchPhotos(args)
 
     return {
         count = #results,
-        photos = results
+        photos = results,
     }
 end
 

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -90,8 +90,53 @@ function M.fakeCatalog(opts)
     local createdCollections = {}
     local createdKeywords = {}
 
+    local function photoMatches(photo, criterion)
+        local crit = criterion.criteria
+        local op = criterion.operation
+        if crit == "filename" and op == "any" then
+            local name = photo:getFormattedMetadata('fileName')
+            if not name then return false end
+            return name:lower():find(criterion.value:lower(), 1, true) ~= nil
+        elseif crit == "rating" and op == "==" then
+            return photo:getRawMetadata('rating') == criterion.value
+        elseif crit == "keywords" and op == "all" then
+            local kws = photo:getRawMetadata('keywords') or {}
+            local target = criterion.value:lower()
+            for _, kw in ipairs(kws) do
+                if kw:getName():lower() == target then return true end
+            end
+            return false
+        elseif crit == "captureTime" then
+            local t = photo:getRawMetadata('dateTimeOriginal')
+            if not t then return false end
+            if op == "inRange" then
+                return t >= criterion.value and t <= criterion.value2
+            elseif op == ">=" then
+                return t >= criterion.value
+            elseif op == "<=" then
+                return t <= criterion.value
+            end
+        end
+        error("fakeCatalog.findPhotos: unsupported criterion " .. tostring(crit) .. "/" .. tostring(op))
+    end
+
     return {
         getAllPhotos = function() return photos end,
+        findPhotos = function(_, opts)
+            local desc = opts and opts.searchDesc or {}
+            local out = {}
+            for _, photo in ipairs(photos) do
+                local ok = true
+                for _, criterion in ipairs(desc) do
+                    if not photoMatches(photo, criterion) then
+                        ok = false
+                        break
+                    end
+                end
+                if ok then table.insert(out, photo) end
+            end
+            return out
+        end,
         getChildCollections = function() return collections end,
         getChildCollectionSets = function() return collectionSets end,
         withReadAccessDo = function(_, fn) fn() end,


### PR DESCRIPTION
## Motivation

`HandlerSearch.searchPhotos` called `catalog:getAllPhotos()` and
filtered in Lua — O(n) per query. ~30s on the small test catalog
(hit MCP timeout); a 50–500k photo catalog is unusable.

Closes #22.

## Implementation information

- Replace iteration with `catalog:findPhotos{searchDesc=...}` so
  Lightroom's indexed search runs the filter natively.
- Map current args to Smart Collection criteria:
  - `filename` → `filename/any`
  - `rating` → `rating/==`
  - `keywords` (each entry) → `keywords/all` (intersect = AND across all)
  - `start_date`+`end_date` → `captureTime/inRange`
  - lone `start_date` / `end_date` → `captureTime/>=` / `<=`
- No filters → fall back to `getAllPhotos()` since `findPhotos`
  rejects an empty criterion list.
- `fakeCatalog` in `plugin/spec/spec_helper.lua` gains a `findPhotos`
  that walks the same criterion shapes the handler emits, so the
  existing 5 `HandlerSearch_spec.lua` cases keep passing untouched.
- MCP tool schema and DISPATCH wiring are unchanged.

## Supporting documentation

- Issue: #22
- Adobe LR SDK: `LrCatalog:findPhotos` / Smart Collection searchDesc

> Changelog: perf(search): rewrite search_photos via findPhotos