### PR TITLE
perf(handlers): cap result size + paginate

### DIFF
--- a/plugin/LightroomMCP.lrplugin/HandlerCollections.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerCollections.lua
@@ -6,49 +6,57 @@ local logger = LrLogger('LightroomMCP')
 local CollectionsHandler = {}
 
 function CollectionsHandler.listCollections(args)
+    args = args or {}
     local catalog = LrApplication.activeCatalog()
-    local collectionsList = {}
+    local all = {}
+
+    local limit = tonumber(args.limit) or 100
+    if limit < 0 then limit = 0 end
+    local offset = tonumber(args.offset) or 0
+    if offset < 0 then offset = 0 end
 
     catalog:withReadAccessDo(function()
-        local collections = catalog:getChildCollections()
-
-        for _, collection in ipairs(collections) do
-            table.insert(collectionsList, {
+        for _, collection in ipairs(catalog:getChildCollections()) do
+            table.insert(all, {
                 name = collection:getName(),
                 type = collection:type(),
-                photoCount = #collection:getPhotos()
+                photoCount = #collection:getPhotos(),
             })
         end
 
-        -- Also get collection sets
-        local collectionSets = catalog:getChildCollectionSets()
-        for _, set in ipairs(collectionSets) do
-            local function addCollectionsFromSet(collSet, prefix)
-                local setCollections = collSet:getChildCollections()
-                for _, coll in ipairs(setCollections) do
-                    table.insert(collectionsList, {
-                        name = prefix .. coll:getName(),
-                        parent = collSet:getName(),
-                        type = coll:type(),
-                        photoCount = #coll:getPhotos()
-                    })
-                end
-
-                local childSets = collSet:getChildCollectionSets()
-                for _, childSet in ipairs(childSets) do
-                    addCollectionsFromSet(childSet, prefix .. childSet:getName() .. " / ")
-                end
+        local function addCollectionsFromSet(collSet, prefix)
+            for _, coll in ipairs(collSet:getChildCollections()) do
+                table.insert(all, {
+                    name = prefix .. coll:getName(),
+                    parent = collSet:getName(),
+                    type = coll:type(),
+                    photoCount = #coll:getPhotos(),
+                })
             end
+            for _, childSet in ipairs(collSet:getChildCollectionSets()) do
+                addCollectionsFromSet(childSet, prefix .. childSet:getName() .. " / ")
+            end
+        end
 
+        for _, set in ipairs(catalog:getChildCollectionSets()) do
             addCollectionsFromSet(set, set:getName() .. " / ")
         end
     end)
 
-    logger:info(string.format("Found %d collections", #collectionsList))
+    local total = #all
+    local last = math.min(offset + limit, total)
+    local slice = {}
+    for i = offset + 1, last do
+        table.insert(slice, all[i])
+    end
+
+    logger:info(string.format("Found %d collections, returning %d (offset=%d, limit=%d)",
+        total, #slice, offset, limit))
 
     return {
-        count = #collectionsList,
-        collections = collectionsList
+        count = total,
+        collections = slice,
+        has_more = (offset + #slice) < total,
     }
 end
 

--- a/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
@@ -54,6 +54,13 @@ function SearchHandler.searchPhotos(args)
     local searchDesc = buildSearchDesc(args)
     local hasFilters = #searchDesc > 0
 
+    local limit = tonumber(args.limit) or 100
+    if limit < 0 then limit = 0 end
+    local offset = tonumber(args.offset) or 0
+    if offset < 0 then offset = 0 end
+
+    local total = 0
+
     catalog:withReadAccessDo(function()
         local matches
         if hasFilters then
@@ -62,16 +69,20 @@ function SearchHandler.searchPhotos(args)
             matches = catalog:getAllPhotos()
         end
 
-        for _, photo in ipairs(matches) do
-            table.insert(results, buildResult(photo))
+        total = #matches
+        local last = math.min(offset + limit, total)
+        for i = offset + 1, last do
+            table.insert(results, buildResult(matches[i]))
         end
     end)
 
-    logger:info(string.format("Search found %d photos", #results))
+    logger:info(string.format("Search matched %d photos, returning %d (offset=%d, limit=%d)",
+        total, #results, offset, limit))
 
     return {
-        count = #results,
+        count = total,
         photos = results,
+        has_more = (offset + #results) < total,
     }
 end
 

--- a/plugin/spec/HandlerCollections_spec.lua
+++ b/plugin/spec/HandlerCollections_spec.lua
@@ -23,6 +23,26 @@ describe("HandlerCollections.listCollections", function()
         assert.are.equal(2, r.count)
         assert.are.equal("Trip", r.collections[1].name)
         assert.are.equal(3, r.collections[1].photoCount)
+        assert.is_false(r.has_more)
+    end)
+
+    it("caps and paginates", function()
+        local cols = {}
+        for i = 1, 150 do
+            table.insert(cols, helper.fakeCollection("c" .. i, {}))
+        end
+        local _, Handler = setup({ collections = cols })
+
+        local r1 = Handler.listCollections({})
+        assert.are.equal(150, r1.count)
+        assert.are.equal(100, #r1.collections)
+        assert.is_true(r1.has_more)
+
+        local r2 = Handler.listCollections({ limit = 50, offset = 100 })
+        assert.are.equal(150, r2.count)
+        assert.are.equal(50, #r2.collections)
+        assert.are.equal("c101", r2.collections[1].name)
+        assert.is_false(r2.has_more)
     end)
 
     it("descends into collection sets and prefixes names", function()

--- a/plugin/spec/HandlerSearch_spec.lua
+++ b/plugin/spec/HandlerSearch_spec.lua
@@ -25,6 +25,7 @@ describe("HandlerSearch.searchPhotos", function()
         local result = Handler.searchPhotos({})
         assert.are.equal(3, result.count)
         assert.are.equal(3, #result.photos)
+        assert.is_false(result.has_more)
     end)
 
     it("filters by rating", function()
@@ -51,5 +52,62 @@ describe("HandlerSearch.searchPhotos", function()
         local result = Handler.searchPhotos({ rating = 1 })
         assert.are.equal(0, result.count)
         assert.are.same({}, result.photos)
+        assert.is_false(result.has_more)
+    end)
+end)
+
+describe("HandlerSearch.searchPhotos pagination", function()
+    local Handler
+
+    before_each(function()
+        local photos = {}
+        for i = 1, 250 do
+            table.insert(photos, helper.fakePhoto({
+                id = tostring(i),
+                path = "/p/" .. i .. ".jpg",
+                fileName = "p" .. i .. ".jpg",
+                rating = 0,
+                dateTimeOriginal = "2024-06-01",
+            }))
+        end
+        local catalog = helper.fakeCatalog({ photos = photos })
+        helper.installImport({
+            LrApplication = { activeCatalog = function() return catalog end },
+            LrLogger = helper.defaultLrLogger(),
+        })
+        package.loaded.HandlerSearch = nil
+        Handler = require 'HandlerSearch'
+    end)
+
+    it("caps to 100 by default and signals has_more", function()
+        local r = Handler.searchPhotos({})
+        assert.are.equal(250, r.count)
+        assert.are.equal(100, #r.photos)
+        assert.is_true(r.has_more)
+        assert.are.equal("1", r.photos[1].id)
+        assert.are.equal("100", r.photos[100].id)
+    end)
+
+    it("respects explicit limit up to total", function()
+        local r = Handler.searchPhotos({ limit = 500 })
+        assert.are.equal(250, r.count)
+        assert.are.equal(250, #r.photos)
+        assert.is_false(r.has_more)
+    end)
+
+    it("paginates via offset", function()
+        local r = Handler.searchPhotos({ limit = 50, offset = 100 })
+        assert.are.equal(250, r.count)
+        assert.are.equal(50, #r.photos)
+        assert.are.equal("101", r.photos[1].id)
+        assert.are.equal("150", r.photos[50].id)
+        assert.is_true(r.has_more)
+    end)
+
+    it("returns empty slice past the end without erroring", function()
+        local r = Handler.searchPhotos({ offset = 1000 })
+        assert.are.equal(250, r.count)
+        assert.are.equal(0, #r.photos)
+        assert.is_false(r.has_more)
     end)
 end)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -44,7 +44,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: "search_photos",
-        description: "Search for photos in Lightroom catalog by criteria",
+        description: "Search for photos in Lightroom catalog by criteria (paginated, default limit 100)",
         inputSchema: {
           type: "object",
           properties: {
@@ -62,6 +62,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             start_date: { type: "string", description: "Start date (YYYY-MM-DD)" },
             end_date: { type: "string", description: "End date (YYYY-MM-DD)" },
+            limit: { type: "number", description: "Max photos to return (default 100)", minimum: 0 },
+            offset: { type: "number", description: "Number of photos to skip (default 0)", minimum: 0 },
           },
         },
       },
@@ -78,8 +80,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "list_collections",
-        description: "List all collections in Lightroom catalog",
-        inputSchema: { type: "object", properties: {} },
+        description: "List all collections in Lightroom catalog (paginated, default limit 100)",
+        inputSchema: {
+          type: "object",
+          properties: {
+            limit: { type: "number", description: "Max collections to return (default 100)", minimum: 0 },
+            offset: { type: "number", description: "Number of collections to skip (default 0)", minimum: 0 },
+          },
+        },
       },
       {
         name: "create_collection",


### PR DESCRIPTION
## Motivation

Closes #23. Handlers returned unbounded arrays — `search_photos` on a large catalog could blow MCP context with thousands of entries.

## Implementation information

- `HandlerSearch.searchPhotos` and `HandlerCollections.listCollections` now read `limit` (default 100) + `offset` (default 0).
- Slice applied **inside** `withReadAccessDo` for search so `buildResult` (4 metadata getters per photo) only runs on the requested window.
- Response shape: `{count: total, photos|collections: slice, has_more: bool}`. `count` is total matches so callers can compute next offset.
- MCP tool schemas in \`server/src/index.ts\` extended with \`limit\`/\`offset\` numeric props (\`minimum: 0\`).
- Pagination tests added to both spec files (250-photo / 150-collection fixtures); existing tests reinforced with \`has_more=false\` assertions.

## Supporting documentation

> Changelog: perf(handlers): cap result size + paginate