### PR TITLE
perf(handlers): bounded path fallback

### DIFF
--- a/plugin/LightroomMCP.lrplugin/HandlerCollections.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerCollections.lua
@@ -1,6 +1,8 @@
 local LrApplication = import 'LrApplication'
 local LrLogger = import 'LrLogger'
 
+local PhotoLookup = require 'PhotoLookup'
+
 local logger = LrLogger('LightroomMCP')
 
 local CollectionsHandler = {}
@@ -139,22 +141,10 @@ function CollectionsHandler.addToCollection(args)
 
         -- Find and add photos
         local photosToAdd = {}
-        for _, photoId in ipairs(args.photo_ids) do
-            local photo = catalog:findPhotoByLocalIdentifier(photoId)
-
-            if not photo then
-                -- Try finding by path
-                local allPhotos = catalog:getAllPhotos()
-                for _, p in ipairs(allPhotos) do
-                    if p:getRawMetadata('path') == photoId then
-                        photo = p
-                        break
-                    end
-                end
-            end
-
-            if photo then
-                table.insert(photosToAdd, photo)
+        local resolved = PhotoLookup.resolveMany(catalog, args.photo_ids)
+        for _, entry in ipairs(resolved) do
+            if entry.photo then
+                table.insert(photosToAdd, entry.photo)
             end
         end
 

--- a/plugin/LightroomMCP.lrplugin/HandlerExport.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerExport.lua
@@ -4,6 +4,8 @@ local LrLogger = import 'LrLogger'
 local LrFileUtils = import 'LrFileUtils'
 local LrPathUtils = import 'LrPathUtils'
 
+local PhotoLookup = require 'PhotoLookup'
+
 local logger = LrLogger('LightroomMCP')
 
 local ExportHandler = {}
@@ -23,22 +25,10 @@ function ExportHandler.exportPhotos(args)
     catalog:withReadAccessDo(function()
         -- Find photos
         local photosToExport = {}
-        for _, photoId in ipairs(args.photo_ids) do
-            local photo = catalog:findPhotoByLocalIdentifier(photoId)
-
-            if not photo then
-                -- Try finding by path
-                local allPhotos = catalog:getAllPhotos()
-                for _, p in ipairs(allPhotos) do
-                    if p:getRawMetadata('path') == photoId then
-                        photo = p
-                        break
-                    end
-                end
-            end
-
-            if photo then
-                table.insert(photosToExport, photo)
+        local resolved = PhotoLookup.resolveMany(catalog, args.photo_ids)
+        for _, entry in ipairs(resolved) do
+            if entry.photo then
+                table.insert(photosToExport, entry.photo)
             end
         end
 

--- a/plugin/LightroomMCP.lrplugin/HandlerMetadata.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerMetadata.lua
@@ -1,6 +1,8 @@
 local LrApplication = import 'LrApplication'
 local LrLogger = import 'LrLogger'
 
+local PhotoLookup = require 'PhotoLookup'
+
 local logger = LrLogger('LightroomMCP')
 
 local MetadataHandler = {}
@@ -14,18 +16,7 @@ function MetadataHandler.getPhotoMetadata(args)
     local photoData = nil
 
     catalog:withReadAccessDo(function()
-        local photo = catalog:findPhotoByLocalIdentifier(args.photo_id)
-
-        if not photo then
-            -- Try finding by path
-            local allPhotos = catalog:getAllPhotos()
-            for _, p in ipairs(allPhotos) do
-                if p:getRawMetadata('path') == args.photo_id then
-                    photo = p
-                    break
-                end
-            end
-        end
+        local photo = PhotoLookup.resolveOne(catalog, args.photo_id)
 
         if not photo then
             error("Photo not found: " .. args.photo_id)

--- a/plugin/LightroomMCP.lrplugin/HandlerOrganization.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerOrganization.lua
@@ -1,6 +1,8 @@
 local LrApplication = import 'LrApplication'
 local LrLogger = import 'LrLogger'
 
+local PhotoLookup = require 'PhotoLookup'
+
 local logger = LrLogger('LightroomMCP')
 
 local OrganizationHandler = {}
@@ -14,20 +16,9 @@ function OrganizationHandler.setKeywords(args)
     local updatedCount = 0
 
     catalog:withWriteAccessDo("Set Keywords", function()
-        for _, photoId in ipairs(args.photo_ids) do
-            local photo = catalog:findPhotoByLocalIdentifier(photoId)
-
-            if not photo then
-                -- Try finding by path
-                local allPhotos = catalog:getAllPhotos()
-                for _, p in ipairs(allPhotos) do
-                    if p:getRawMetadata('path') == photoId then
-                        photo = p
-                        break
-                    end
-                end
-            end
-
+        local resolved = PhotoLookup.resolveMany(catalog, args.photo_ids)
+        for _, entry in ipairs(resolved) do
+            local photo = entry.photo
             if photo then
                 -- Add keywords
                 if args.add_keywords and #args.add_keywords > 0 then
@@ -81,22 +72,10 @@ function OrganizationHandler.setRating(args)
     local updatedCount = 0
 
     catalog:withWriteAccessDo("Set Rating", function()
-        for _, photoId in ipairs(args.photo_ids) do
-            local photo = catalog:findPhotoByLocalIdentifier(photoId)
-
-            if not photo then
-                -- Try finding by path
-                local allPhotos = catalog:getAllPhotos()
-                for _, p in ipairs(allPhotos) do
-                    if p:getRawMetadata('path') == photoId then
-                        photo = p
-                        break
-                    end
-                end
-            end
-
-            if photo then
-                photo:setRawMetadata('rating', args.rating)
+        local resolved = PhotoLookup.resolveMany(catalog, args.photo_ids)
+        for _, entry in ipairs(resolved) do
+            if entry.photo then
+                entry.photo:setRawMetadata('rating', args.rating)
                 updatedCount = updatedCount + 1
             end
         end

--- a/plugin/LightroomMCP.lrplugin/PhotoLookup.lua
+++ b/plugin/LightroomMCP.lrplugin/PhotoLookup.lua
@@ -1,0 +1,41 @@
+local PhotoLookup = {}
+
+-- Resolve a list of photo identifiers to photo objects.
+-- Each id may be a numeric local identifier (string or number) or a file path.
+-- Builds the path index AT MOST ONCE per call, and only when at least one id
+-- missed local-id lookup. Returns a parallel array:
+--   results[i] = { id = inputId, photo = photoOrNil }
+function PhotoLookup.resolveMany(catalog, photoIds)
+    local results = {}
+    local missingIdx = {}
+
+    for i, id in ipairs(photoIds) do
+        local photo = nil
+        local numId = tonumber(id)
+        if numId then
+            photo = catalog:findPhotoByLocalIdentifier(numId)
+        end
+        results[i] = { id = id, photo = photo }
+        if not photo then
+            table.insert(missingIdx, i)
+        end
+    end
+
+    if #missingIdx > 0 then
+        local byPath = {}
+        for _, p in ipairs(catalog:getAllPhotos()) do
+            byPath[p:getRawMetadata('path')] = p
+        end
+        for _, idx in ipairs(missingIdx) do
+            results[idx].photo = byPath[results[idx].id]
+        end
+    end
+
+    return results
+end
+
+function PhotoLookup.resolveOne(catalog, photoId)
+    return PhotoLookup.resolveMany(catalog, { photoId })[1].photo
+end
+
+return PhotoLookup

--- a/plugin/spec/PhotoLookup_spec.lua
+++ b/plugin/spec/PhotoLookup_spec.lua
@@ -1,0 +1,130 @@
+local function fakePhoto(id, path)
+    return {
+        localIdentifier = id,
+        getRawMetadata = function(_, key)
+            if key == 'path' then return path end
+            return nil
+        end,
+    }
+end
+
+local function fakeCatalog(photos)
+    local state = { getAllPhotosCalls = 0, findByIdCalls = 0 }
+    local catalog = {
+        getAllPhotos = function()
+            state.getAllPhotosCalls = state.getAllPhotosCalls + 1
+            return photos
+        end,
+        findPhotoByLocalIdentifier = function(_, id)
+            state.findByIdCalls = state.findByIdCalls + 1
+            for _, p in ipairs(photos) do
+                if p.localIdentifier == id then return p end
+            end
+            return nil
+        end,
+    }
+    return catalog, state
+end
+
+local PhotoLookup
+local function loadModule()
+    package.loaded.PhotoLookup = nil
+    PhotoLookup = require 'PhotoLookup'
+end
+
+describe("PhotoLookup.resolveMany", function()
+    before_each(loadModule)
+
+    it("resolves all-numeric ids without scanning the catalog", function()
+        local p1 = fakePhoto(1, "/a.jpg")
+        local p2 = fakePhoto(2, "/b.jpg")
+        local catalog, state = fakeCatalog({ p1, p2 })
+
+        local r = PhotoLookup.resolveMany(catalog, { "1", "2" })
+
+        assert.are.equal(p1, r[1].photo)
+        assert.are.equal(p2, r[2].photo)
+        assert.are.equal(0, state.getAllPhotosCalls)
+        assert.are.equal(2, state.findByIdCalls)
+    end)
+
+    it("falls back to path lookup with exactly one scan", function()
+        local p1 = fakePhoto(1, "/a.jpg")
+        local p2 = fakePhoto(2, "/b.jpg")
+        local catalog, state = fakeCatalog({ p1, p2 })
+
+        local r = PhotoLookup.resolveMany(catalog, { "/a.jpg", "/b.jpg" })
+
+        assert.are.equal(p1, r[1].photo)
+        assert.are.equal(p2, r[2].photo)
+        assert.are.equal(1, state.getAllPhotosCalls)
+    end)
+
+    it("does one scan for a mixed batch (some by id, some by path)", function()
+        local p1 = fakePhoto(1, "/a.jpg")
+        local p2 = fakePhoto(2, "/b.jpg")
+        local p3 = fakePhoto(3, "/c.jpg")
+        local catalog, state = fakeCatalog({ p1, p2, p3 })
+
+        local r = PhotoLookup.resolveMany(catalog, { "1", "/b.jpg", "3" })
+
+        assert.are.equal(p1, r[1].photo)
+        assert.are.equal(p2, r[2].photo)
+        assert.are.equal(p3, r[3].photo)
+        assert.are.equal(1, state.getAllPhotosCalls)
+    end)
+
+    it("returns nil for unknown ids without erroring", function()
+        local p1 = fakePhoto(1, "/a.jpg")
+        local catalog, state = fakeCatalog({ p1 })
+
+        local r = PhotoLookup.resolveMany(catalog, { "1", "999", "/missing.jpg" })
+
+        assert.are.equal(p1, r[1].photo)
+        assert.is_nil(r[2].photo)
+        assert.is_nil(r[3].photo)
+        -- One scan triggered by the misses; not three.
+        assert.are.equal(1, state.getAllPhotosCalls)
+    end)
+
+    it("preserves input order in results", function()
+        local p1 = fakePhoto(1, "/a.jpg")
+        local p2 = fakePhoto(2, "/b.jpg")
+        local catalog, _ = fakeCatalog({ p1, p2 })
+
+        local r = PhotoLookup.resolveMany(catalog, { "/b.jpg", "1", "/a.jpg", "2" })
+
+        assert.are.equal(p2, r[1].photo)
+        assert.are.equal(p1, r[2].photo)
+        assert.are.equal(p1, r[3].photo)
+        assert.are.equal(p2, r[4].photo)
+    end)
+
+    it("handles empty input", function()
+        local catalog, state = fakeCatalog({})
+        local r = PhotoLookup.resolveMany(catalog, {})
+        assert.are.equal(0, #r)
+        assert.are.equal(0, state.getAllPhotosCalls)
+    end)
+end)
+
+describe("PhotoLookup.resolveOne", function()
+    before_each(loadModule)
+
+    it("returns the matching photo by local id", function()
+        local p1 = fakePhoto(1, "/a.jpg")
+        local catalog, _ = fakeCatalog({ p1 })
+        assert.are.equal(p1, PhotoLookup.resolveOne(catalog, "1"))
+    end)
+
+    it("returns the matching photo by path", function()
+        local p1 = fakePhoto(1, "/a.jpg")
+        local catalog, _ = fakeCatalog({ p1 })
+        assert.are.equal(p1, PhotoLookup.resolveOne(catalog, "/a.jpg"))
+    end)
+
+    it("returns nil when nothing matches", function()
+        local catalog, _ = fakeCatalog({})
+        assert.is_nil(PhotoLookup.resolveOne(catalog, "missing"))
+    end)
+end)

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -142,8 +142,9 @@ function M.fakeCatalog(opts)
         withReadAccessDo = function(_, fn) fn() end,
         withWriteAccessDo = function(_, _, fn) fn() end,
         findPhotoByLocalIdentifier = function(_, id)
+            local target = tostring(id)
             for _, p in ipairs(photos) do
-                if p.localIdentifier == id then return p end
+                if tostring(p.localIdentifier) == target then return p end
             end
             return nil
         end,


### PR DESCRIPTION
## Motivation

Closes #24. Handlers fell back to a full `getAllPhotos()` scan
on every `photo_id` miss, making `set_rating` over 50 ids on a
100k catalog effectively unusable. Worse, ids arrive as JSON
strings but `findPhotoByLocalIdentifier` expects numbers, so
the local-id path silently missed for every input and forced
the fallback every time.

## Implementation information

Added a shared `PhotoLookup` module used by all handlers. It
coerces ids via `tonumber`, then builds a path → photo map
at most once per call, and only when at least one id missed
local-id lookup. Result for 50 ids on 100k catalog: ~50 hash
lookups (best case) or ~100k iters (worst case), down from 5M.

Refactored `HandlerMetadata.getPhotoMetadata`,
`HandlerOrganization.setKeywords`,
`HandlerOrganization.setRating`,
`HandlerCollections.addToCollection`, and
`HandlerExport.exportPhotos` to call `PhotoLookup.resolveMany`
or `PhotoLookup.resolveOne`.

Alternative considered: drop the path fallback entirely
(Option A in #24). Rejected — would break the documented
contract and the existing `HandlerMetadata` test that pins
path-based lookup.

`spec_helper.lua` mock for `findPhotoByLocalIdentifier` now
compares via `tostring` so the existing string-id specs keep
passing once handlers coerce to numbers.

New `plugin/spec/PhotoLookup_spec.lua` (9 cases) asserts
scan-count behaviour: 0 scans on all-id-hit, 1 scan on
path-only, 1 scan mixed, ordering preserved, unknowns
return nil.

## Supporting documentation

Issue: #24