### PR TITLE
feat(tool): add get_selected_photos

### DIFF
--- a/plugin/LightroomMCP.lrplugin/HandlerSelection.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSelection.lua
@@ -1,0 +1,49 @@
+local LrApplication = import 'LrApplication'
+local LrLogger = import 'LrLogger'
+
+local logger = LrLogger('LightroomMCP')
+
+local SelectionHandler = {}
+
+local function buildResult(photo)
+    return {
+        id = photo.localIdentifier,
+        path = photo:getRawMetadata('path'),
+        filename = photo:getFormattedMetadata('fileName'),
+        rating = photo:getRawMetadata('rating'),
+        dateTimeOriginal = photo:getFormattedMetadata('dateTimeOriginal'),
+    }
+end
+
+function SelectionHandler.getSelectedPhotos(args)
+    args = args or {}
+    local catalog = LrApplication.activeCatalog()
+
+    local limit = tonumber(args.limit) or 100
+    if limit < 0 then limit = 0 end
+    local offset = tonumber(args.offset) or 0
+    if offset < 0 then offset = 0 end
+
+    local results = {}
+    local total = 0
+
+    catalog:withReadAccessDo(function()
+        local matches = catalog:getTargetPhotos() or {}
+        total = #matches
+        local last = math.min(offset + limit, total)
+        for i = offset + 1, last do
+            table.insert(results, buildResult(matches[i]))
+        end
+    end)
+
+    logger:info(string.format("getTargetPhotos returned %d, paged %d (offset=%d, limit=%d)",
+        total, #results, offset, limit))
+
+    return {
+        count = total,
+        photos = results,
+        has_more = (offset + #results) < total,
+    }
+end
+
+return SelectionHandler

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -11,6 +11,7 @@ local HandlerMetadata = require 'HandlerMetadata'
 local HandlerOrganization = require 'HandlerOrganization'
 local HandlerImport = require 'HandlerImport'
 local HandlerExport = require 'HandlerExport'
+local HandlerSelection = require 'HandlerSelection'
 
 local logger = LrLogger('LightroomMCP')
 logger:enable("logfile")
@@ -47,6 +48,7 @@ local DISPATCH = {
     set_rating = HandlerOrganization.setRating,
     import_photos = HandlerImport.importPhotos,
     export_photos = HandlerExport.exportPhotos,
+    get_selected_photos = HandlerSelection.getSelectedPhotos,
 }
 
 local SEND_WAIT_SECONDS = 5

--- a/plugin/spec/HandlerSelection_spec.lua
+++ b/plugin/spec/HandlerSelection_spec.lua
@@ -1,0 +1,91 @@
+local helper = require 'spec_helper'
+
+describe("HandlerSelection.getSelectedPhotos", function()
+    local Handler
+
+    local function setup(opts)
+        local catalog = helper.fakeCatalog(opts)
+        helper.installImport({
+            LrApplication = { activeCatalog = function() return catalog end },
+            LrLogger = helper.defaultLrLogger(),
+        })
+        package.loaded.HandlerSelection = nil
+        Handler = require 'HandlerSelection'
+    end
+
+    it("returns selected photos when selection is non-empty", function()
+        local p1 = helper.fakePhoto({ id = "1", path = "/a.jpg", fileName = "a.jpg", rating = 5 })
+        local p2 = helper.fakePhoto({ id = "2", path = "/b.jpg", fileName = "b.jpg", rating = 3 })
+        local p3 = helper.fakePhoto({ id = "3", path = "/c.jpg", fileName = "c.jpg", rating = 0 })
+        setup({ photos = { p1, p2, p3 }, targetPhotos = { p1, p3 } })
+
+        local r = Handler.getSelectedPhotos({})
+        assert.are.equal(2, r.count)
+        assert.are.equal("1", r.photos[1].id)
+        assert.are.equal("3", r.photos[2].id)
+        assert.is_false(r.has_more)
+    end)
+
+    it("falls back to filmstrip when no selection (targetPhotos defaults to all)", function()
+        setup({
+            photos = {
+                helper.fakePhoto({ id = "1", fileName = "a.jpg" }),
+                helper.fakePhoto({ id = "2", fileName = "b.jpg" }),
+            },
+        })
+        local r = Handler.getSelectedPhotos({})
+        assert.are.equal(2, r.count)
+        assert.are.equal(2, #r.photos)
+    end)
+
+    it("returns serialized photo fields", function()
+        setup({
+            photos = { helper.fakePhoto({
+                id = "42", path = "/x.jpg", fileName = "x.jpg",
+                rating = 4, dateTimeOriginal = "2026-05-06",
+            }) },
+        })
+        local r = Handler.getSelectedPhotos({})
+        local p = r.photos[1]
+        assert.are.equal("42", p.id)
+        assert.are.equal("/x.jpg", p.path)
+        assert.are.equal("x.jpg", p.filename)
+        assert.are.equal(4, p.rating)
+        assert.are.equal("2026-05-06", p.dateTimeOriginal)
+    end)
+
+    it("paginates via limit and offset", function()
+        local photos = {}
+        for i = 1, 250 do
+            table.insert(photos, helper.fakePhoto({ id = tostring(i), fileName = "p" .. i .. ".jpg" }))
+        end
+        setup({ photos = photos })
+
+        local r = Handler.getSelectedPhotos({ limit = 50, offset = 100 })
+        assert.are.equal(250, r.count)
+        assert.are.equal(50, #r.photos)
+        assert.are.equal("101", r.photos[1].id)
+        assert.is_true(r.has_more)
+    end)
+
+    it("caps to 100 by default", function()
+        local photos = {}
+        for i = 1, 150 do
+            table.insert(photos, helper.fakePhoto({ id = tostring(i), fileName = "p.jpg" }))
+        end
+        setup({ photos = photos })
+
+        local r = Handler.getSelectedPhotos({})
+        assert.are.equal(150, r.count)
+        assert.are.equal(100, #r.photos)
+        assert.is_true(r.has_more)
+    end)
+
+    it("returns empty when nothing is targeted", function()
+        setup({ photos = {}, targetPhotos = {} })
+        local r = Handler.getSelectedPhotos({})
+        assert.are.equal(0, r.count)
+        assert.are.same({}, r.photos)
+        assert.is_false(r.has_more)
+    end)
+end)

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -122,6 +122,7 @@ function M.fakeCatalog(opts)
 
     return {
         getAllPhotos = function() return photos end,
+        getTargetPhotos = function() return opts.targetPhotos or photos end,
         findPhotos = function(_, opts)
             local desc = opts and opts.searchDesc or {}
             local out = {}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -68,6 +68,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "get_selected_photos",
+        description: "Get currently selected photos in Lightroom (or filmstrip if no selection). Paginated, default limit 100.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            limit: { type: "number", description: "Max photos to return (default 100)", minimum: 0 },
+            offset: { type: "number", description: "Number of photos to skip (default 0)", minimum: 0 },
+          },
+        },
+      },
+      {
         name: "get_photo_metadata",
         description: "Get detailed metadata for a specific photo",
         inputSchema: {


### PR DESCRIPTION
## Motivation

Closes #25. Natural Claude workflow ("rate the photos I have selected", "look at what I'm working on") was impossible — no tool exposed Lightroom's current selection.

## Implementation information

New `get_selected_photos` tool. Plugin handler calls `LrApplication.activeCatalog():getTargetPhotos()` inside `withReadAccessDo` — LR's standard "selection or filmstrip" semantics. Response mirrors `search_photos` shape (`{count, photos, has_more}`) so the LLM can chain it with `set_rating`, `set_keywords`, etc.

Departed from issue spec on one point: added optional `limit`/`offset` (default 100). Issue specified `properties: {}`, but the filmstrip fallback can be thousands of photos — recent perf commits (#33/#34/#35) capped/paginated every other photo-listing tool. Staying consistent with that direction.

`buildResult` is duplicated inline rather than extracted into a shared serializer — matches existing convention (`HandlerSearch.lua`, `HandlerMetadata.lua` each inline their own).

`spec_helper.fakeCatalog` extended with `getTargetPhotos` (defaults to `photos`, accepts explicit `targetPhotos` override) so tests can exercise both selection and filmstrip-fallback paths.

## Supporting documentation

- Issue: #25
- Verification: tsc clean, jest 21/21, busted 52/52 (6 new). Local luacheck has a Lua 5.5 incompat unrelated to this change; CI runs it on Ubuntu.
- Manual LR test pending: select N photos → call tool → expect `count=N` with those photo paths.

> Changelog: feat(tool): add get_selected_photos