### PR TITLE
feat(develop): add develop module tools

### DIFF
--- a/plugin/LightroomMCP.lrplugin/HandlerDevelop.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerDevelop.lua
@@ -1,0 +1,156 @@
+local LrApplication = import 'LrApplication'
+local LrLogger = import 'LrLogger'
+
+local PhotoLookup = require 'PhotoLookup'
+
+local logger = LrLogger('LightroomMCP')
+
+local DevelopHandler = {}
+
+local function findPresetByName(name)
+    for _, folder in ipairs(LrApplication.developPresetFolders()) do
+        for _, preset in ipairs(folder:getDevelopPresets()) do
+            if preset:getName() == name then
+                return preset, folder:getName()
+            end
+        end
+    end
+    return nil, nil
+end
+
+function DevelopHandler.listDevelopPresets(_)
+    local out = {}
+    for _, folder in ipairs(LrApplication.developPresetFolders()) do
+        local fname = folder:getName()
+        for _, preset in ipairs(folder:getDevelopPresets()) do
+            table.insert(out, { name = preset:getName(), folder = fname })
+        end
+    end
+
+    logger:info(string.format("Listed %d develop presets", #out))
+
+    return {
+        success = true,
+        presets = out,
+        count = #out,
+    }
+end
+
+function DevelopHandler.applyDevelopPreset(args)
+    if not args.photo_ids or #args.photo_ids == 0 then
+        error("photo_ids is required")
+    end
+
+    if not args.preset_name then
+        error("preset_name is required")
+    end
+
+    local preset, folder = findPresetByName(args.preset_name)
+    if not preset then
+        error("Preset not found: " .. args.preset_name)
+    end
+
+    local catalog = LrApplication.activeCatalog()
+    local appliedCount = 0
+
+    catalog:withWriteAccessDo("Apply Develop Preset", function()
+        local resolved = PhotoLookup.resolveMany(catalog, args.photo_ids)
+        for _, entry in ipairs(resolved) do
+            if entry.photo then
+                entry.photo:applyDevelopPreset(preset)
+                appliedCount = appliedCount + 1
+            end
+        end
+    end)
+
+    logger:info(string.format("Applied preset %s to %d photos", args.preset_name, appliedCount))
+
+    return {
+        success = true,
+        applied = appliedCount,
+        preset = args.preset_name,
+        folder = folder,
+        message = string.format("Applied preset %s to %d photos", args.preset_name, appliedCount),
+    }
+end
+
+function DevelopHandler.copyDevelopSettings(args)
+    if not args.source_id then
+        error("source_id is required")
+    end
+
+    if not args.target_ids or #args.target_ids == 0 then
+        error("target_ids is required")
+    end
+
+    local catalog = LrApplication.activeCatalog()
+    local sourceSettings
+
+    catalog:withReadAccessDo(function()
+        local source = PhotoLookup.resolveOne(catalog, args.source_id)
+        if not source then
+            error("Source photo not found: " .. args.source_id)
+        end
+        sourceSettings = source:getDevelopSettings()
+    end)
+
+    local toApply = sourceSettings
+    if args.settings and #args.settings > 0 then
+        toApply = {}
+        for _, key in ipairs(args.settings) do
+            toApply[key] = sourceSettings[key]
+        end
+    end
+
+    local copiedCount = 0
+
+    catalog:withWriteAccessDo("Copy Develop Settings", function()
+        local resolved = PhotoLookup.resolveMany(catalog, args.target_ids)
+        for _, entry in ipairs(resolved) do
+            if entry.photo then
+                entry.photo:applyDevelopSettings(toApply)
+                copiedCount = copiedCount + 1
+            end
+        end
+    end)
+
+    logger:info(string.format("Copied develop settings from %s to %d photos", args.source_id, copiedCount))
+
+    return {
+        success = true,
+        copied = copiedCount,
+        source = args.source_id,
+        message = string.format("Copied develop settings from %s to %d photos", args.source_id, copiedCount),
+    }
+end
+
+function DevelopHandler.setDevelopSettings(args)
+    if not args.photo_id then
+        error("photo_id is required")
+    end
+
+    if not args.settings or type(args.settings) ~= "table" then
+        error("settings is required")
+    end
+
+    local catalog = LrApplication.activeCatalog()
+    local applied = false
+
+    catalog:withWriteAccessDo("Set Develop Settings", function()
+        local photo = PhotoLookup.resolveOne(catalog, args.photo_id)
+        if not photo then
+            error("Photo not found: " .. args.photo_id)
+        end
+        photo:applyDevelopSettings(args.settings)
+        applied = true
+    end)
+
+    logger:info(string.format("Set develop settings on photo %s", args.photo_id))
+
+    return {
+        success = applied,
+        photo_id = args.photo_id,
+    }
+end
+
+return DevelopHandler

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -12,6 +12,7 @@ local HandlerOrganization = require 'HandlerOrganization'
 local HandlerImport = require 'HandlerImport'
 local HandlerExport = require 'HandlerExport'
 local HandlerSelection = require 'HandlerSelection'
+local HandlerDevelop = require 'HandlerDevelop'
 
 local logger = LrLogger('LightroomMCP')
 logger:enable("logfile")
@@ -49,6 +50,10 @@ local DISPATCH = {
     import_photos = HandlerImport.importPhotos,
     export_photos = HandlerExport.exportPhotos,
     get_selected_photos = HandlerSelection.getSelectedPhotos,
+    list_develop_presets = HandlerDevelop.listDevelopPresets,
+    apply_develop_preset = HandlerDevelop.applyDevelopPreset,
+    copy_develop_settings = HandlerDevelop.copyDevelopSettings,
+    set_develop_settings = HandlerDevelop.setDevelopSettings,
 }
 
 local SEND_WAIT_SECONDS = 5

--- a/plugin/spec/HandlerDevelop_spec.lua
+++ b/plugin/spec/HandlerDevelop_spec.lua
@@ -1,0 +1,190 @@
+local helper = require 'spec_helper'
+
+local function fakePreset(name)
+    return { getName = function() return name end }
+end
+
+local function fakeFolder(name, presets)
+    return {
+        getName = function() return name end,
+        getDevelopPresets = function() return presets end,
+    }
+end
+
+local function setup(opts)
+    opts = opts or {}
+    local catalog = helper.fakeCatalog({ photos = opts.photos or {} })
+    helper.installImport({
+        LrApplication = {
+            activeCatalog = function() return catalog end,
+            developPresetFolders = function() return opts.folders or {} end,
+        },
+        LrLogger = helper.defaultLrLogger(),
+    })
+    package.loaded.HandlerDevelop = nil
+    return catalog, require 'HandlerDevelop'
+end
+
+describe("HandlerDevelop.listDevelopPresets", function()
+    it("returns flat list with name + folder", function()
+        local folders = {
+            fakeFolder("User Presets", { fakePreset("Vibrant"), fakePreset("Moody") }),
+            fakeFolder("Adobe Color", { fakePreset("Standard") }),
+        }
+        local _, Handler = setup({ folders = folders })
+
+        local r = Handler.listDevelopPresets({})
+
+        assert.is_true(r.success)
+        assert.are.equal(3, r.count)
+        assert.are.equal(3, #r.presets)
+        assert.are.equal("Vibrant", r.presets[1].name)
+        assert.are.equal("User Presets", r.presets[1].folder)
+        assert.are.equal("Standard", r.presets[3].name)
+        assert.are.equal("Adobe Color", r.presets[3].folder)
+    end)
+
+    it("returns empty list when no folders", function()
+        local _, Handler = setup({ folders = {} })
+        local r = Handler.listDevelopPresets({})
+        assert.are.equal(0, r.count)
+        assert.are.same({}, r.presets)
+    end)
+end)
+
+describe("HandlerDevelop.applyDevelopPreset", function()
+    it("applies preset to resolved photos", function()
+        local p1 = helper.fakePhoto({ id = "1", path = "/a.jpg" })
+        local p2 = helper.fakePhoto({ id = "2", path = "/b.jpg" })
+        local preset = fakePreset("Vibrant")
+        local folders = { fakeFolder("User", { preset }) }
+        local _, Handler = setup({ photos = { p1, p2 }, folders = folders })
+
+        local r = Handler.applyDevelopPreset({ photo_ids = { "1", "2" }, preset_name = "Vibrant" })
+
+        assert.is_true(r.success)
+        assert.are.equal(2, r.applied)
+        assert.are.equal("Vibrant", r.preset)
+        assert.are.equal("User", r.folder)
+        assert.are.equal(preset, p1.getRawMetadata(p1, "__appliedPreset"))
+        assert.are.equal(preset, p2.getRawMetadata(p2, "__appliedPreset"))
+    end)
+
+    it("skips unresolved photos", function()
+        local p1 = helper.fakePhoto({ id = "1", path = "/a.jpg" })
+        local folders = { fakeFolder("User", { fakePreset("Moody") }) }
+        local _, Handler = setup({ photos = { p1 }, folders = folders })
+
+        local r = Handler.applyDevelopPreset({ photo_ids = { "1", "missing" }, preset_name = "Moody" })
+
+        assert.are.equal(1, r.applied)
+    end)
+
+    it("errors on unknown preset", function()
+        local p1 = helper.fakePhoto({ id = "1", path = "/a.jpg" })
+        local folders = { fakeFolder("User", { fakePreset("Vibrant") }) }
+        local _, Handler = setup({ photos = { p1 }, folders = folders })
+
+        assert.has_error(function()
+            Handler.applyDevelopPreset({ photo_ids = { "1" }, preset_name = "Nope" })
+        end)
+    end)
+
+    it("requires photo_ids and preset_name", function()
+        local _, Handler = setup({ folders = { fakeFolder("U", { fakePreset("X") }) } })
+        assert.has_error(function() Handler.applyDevelopPreset({ preset_name = "X" }) end)
+        assert.has_error(function() Handler.applyDevelopPreset({ photo_ids = { "1" } }) end)
+        assert.has_error(function() Handler.applyDevelopPreset({ photo_ids = {}, preset_name = "X" }) end)
+    end)
+end)
+
+describe("HandlerDevelop.copyDevelopSettings", function()
+    it("copies all settings from source to targets", function()
+        local source = helper.fakePhoto({
+            id = "10", path = "/s.jpg",
+            developSettings = { Exposure2012 = 1.0, Contrast2012 = 25, WhiteBalance = "Custom" },
+        })
+        local t1 = helper.fakePhoto({ id = "11", path = "/t1.jpg" })
+        local t2 = helper.fakePhoto({ id = "12", path = "/t2.jpg" })
+        local _, Handler = setup({ photos = { source, t1, t2 } })
+
+        local r = Handler.copyDevelopSettings({ source_id = "10", target_ids = { "11", "12" } })
+
+        assert.is_true(r.success)
+        assert.are.equal(2, r.copied)
+        assert.are.same(
+            { Exposure2012 = 1.0, Contrast2012 = 25, WhiteBalance = "Custom" },
+            t1.getRawMetadata(t1, "__appliedSettings")
+        )
+        assert.are.same(
+            { Exposure2012 = 1.0, Contrast2012 = 25, WhiteBalance = "Custom" },
+            t2.getRawMetadata(t2, "__appliedSettings")
+        )
+    end)
+
+    it("filters by settings whitelist", function()
+        local source = helper.fakePhoto({
+            id = "20", path = "/s.jpg",
+            developSettings = { Exposure2012 = 0.5, Contrast2012 = 10, Saturation = 20 },
+        })
+        local target = helper.fakePhoto({ id = "21", path = "/t.jpg" })
+        local _, Handler = setup({ photos = { source, target } })
+
+        Handler.copyDevelopSettings({
+            source_id = "20",
+            target_ids = { "21" },
+            settings = { "Exposure2012", "Saturation" },
+        })
+
+        local applied = target.getRawMetadata(target, "__appliedSettings")
+        assert.are.equal(0.5, applied.Exposure2012)
+        assert.are.equal(20, applied.Saturation)
+        assert.is_nil(applied.Contrast2012)
+    end)
+
+    it("errors when source missing", function()
+        local _, Handler = setup({ photos = {} })
+        assert.has_error(function()
+            Handler.copyDevelopSettings({ source_id = "missing", target_ids = { "t" } })
+        end)
+    end)
+
+    it("requires source_id and target_ids", function()
+        local _, Handler = setup({})
+        assert.has_error(function() Handler.copyDevelopSettings({ target_ids = { "t" } }) end)
+        assert.has_error(function() Handler.copyDevelopSettings({ source_id = "s" }) end)
+        assert.has_error(function() Handler.copyDevelopSettings({ source_id = "s", target_ids = {} }) end)
+    end)
+end)
+
+describe("HandlerDevelop.setDevelopSettings", function()
+    it("applies settings to the photo", function()
+        local p = helper.fakePhoto({ id = "1", path = "/a.jpg" })
+        local _, Handler = setup({ photos = { p } })
+
+        local r = Handler.setDevelopSettings({
+            photo_id = "1",
+            settings = { Exposure2012 = 0.75, Contrast2012 = 15 },
+        })
+
+        assert.is_true(r.success)
+        assert.are.same(
+            { Exposure2012 = 0.75, Contrast2012 = 15 },
+            p.getRawMetadata(p, "__appliedSettings")
+        )
+    end)
+
+    it("errors when photo not found", function()
+        local _, Handler = setup({ photos = {} })
+        assert.has_error(function()
+            Handler.setDevelopSettings({ photo_id = "missing", settings = { Exposure2012 = 1 } })
+        end)
+    end)
+
+    it("requires photo_id and settings table", function()
+        local _, Handler = setup({})
+        assert.has_error(function() Handler.setDevelopSettings({ settings = {} }) end)
+        assert.has_error(function() Handler.setDevelopSettings({ photo_id = "1" }) end)
+        assert.has_error(function() Handler.setDevelopSettings({ photo_id = "1", settings = "not-a-table" }) end)
+    end)
+end)

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -57,6 +57,12 @@ function M.fakePhoto(meta)
             table.insert(meta.__removedKeywords, kw)
         end,
         setRawMetadata = function(_, key, value) meta[key] = value end,
+        applyDevelopPreset = function(_, preset)
+            meta.__appliedPreset = preset
+        end,
+        applyDevelopSettings = function(_, settings)
+            meta.__appliedSettings = settings
+        end,
     }
 end
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -222,6 +222,75 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["photo_ids", "destination"],
         },
       },
+      {
+        name: "list_develop_presets",
+        description: "List available Develop presets across all preset folders",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "apply_develop_preset",
+        description: "Apply a named Develop preset to one or more photos",
+        inputSchema: {
+          type: "object",
+          properties: {
+            photo_ids: {
+              type: "array",
+              items: { type: "string" },
+              description: "Array of photo IDs or file paths",
+            },
+            preset_name: {
+              type: "string",
+              description: "Preset name (first match across folders)",
+            },
+          },
+          required: ["photo_ids", "preset_name"],
+        },
+      },
+      {
+        name: "copy_develop_settings",
+        description: "Copy Develop settings from one photo to others",
+        inputSchema: {
+          type: "object",
+          properties: {
+            source_id: {
+              type: "string",
+              description: "Source photo ID or file path",
+            },
+            target_ids: {
+              type: "array",
+              items: { type: "string" },
+              description: "Target photo IDs or file paths",
+            },
+            settings: {
+              type: "array",
+              items: { type: "string" },
+              description: "Optional whitelist of SDK setting keys (e.g., Exposure2012, Contrast2012). Omit to copy all.",
+            },
+          },
+          required: ["source_id", "target_ids"],
+        },
+      },
+      {
+        name: "set_develop_settings",
+        description: "Set Develop settings directly on a photo. Keys use Lightroom SDK names (Exposure2012, WhiteBalance, Contrast2012, Highlights2012, Shadows2012, Whites2012, Blacks2012, Clarity2012, Vibrance, Saturation, etc.)",
+        inputSchema: {
+          type: "object",
+          properties: {
+            photo_id: {
+              type: "string",
+              description: "Photo ID or file path",
+            },
+            settings: {
+              type: "object",
+              description: "SDK setting key/value pairs (e.g., {\"Exposure2012\": 0.5})",
+            },
+          },
+          required: ["photo_id", "settings"],
+        },
+      },
     ],
   };
 });


### PR DESCRIPTION
## Motivation

Closes #26. Current tools are metadata + organization only. The big AI value-add for photographers is "make these all look like that one" — needs Develop module access.

## Implementation information

Adds `HandlerDevelop.lua` with 4 functions, wired through `PluginInfoProvider.DISPATCH` and exposed as 4 MCP tools in `server/src/index.ts`:

- `list_develop_presets` — walks `LrApplication.developPresetFolders()`, returns `{name, folder}` pairs
- `apply_develop_preset {photo_ids, preset_name}` — first-match preset lookup by name across all folders, applies via `photo:applyDevelopPreset(preset)`
- `copy_develop_settings {source_id, target_ids, settings?}` — reads source via `photo:getDevelopSettings()`, applies to targets via `photo:applyDevelopSettings(table)`. Optional `settings` array filters which SDK keys to copy
- `set_develop_settings {photo_id, settings}` — direct `photo:applyDevelopSettings(table)` with SDK CamelCase keys (Exposure2012, WhiteBalance, etc.)

Reuses `PhotoLookup.resolveMany`/`resolveOne` for ID/path resolution. Wraps mutations in `catalog:withWriteAccessDo`. Photo API works without `LrApplicationView.switchToModule("develop")` so module switching omitted.

Busted spec covers all 4 functions: validation errors, unresolved photos skipped, whitelist filter, full-table copy, unknown preset error. `spec_helper.fakePhoto` extended with `applyDevelopPreset`/`applyDevelopSettings` capture stubs.

## Supporting documentation

- Issue #26
- Pattern mirrors `HandlerOrganization.lua` + `HandlerOrganization_spec.lua`

> Changelog: feat(develop): add develop module tools