### PR TITLE
feat(plugin): auto-start server on launch

### DIFF
--- a/plugin/LightroomMCP.lrplugin/Info.lua
+++ b/plugin/LightroomMCP.lrplugin/Info.lua
@@ -10,4 +10,5 @@ return {
     VERSION = { major=0, minor=1, revision=0, build=0 },
 
     LrPluginInfoProvider = 'PluginInfoProvider.lua',
+    LrInitPlugin = 'PluginInit.lua',
 }

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -3,6 +3,8 @@ local LrLogger = import 'LrLogger'
 local LrDialogs = import 'LrDialogs'
 local LrFunctionContext = import 'LrFunctionContext'
 local LrSocket = import 'LrSocket'
+local LrPrefs = import 'LrPrefs'
+local LrView = import 'LrView'
 
 local JSON = require 'JSON'
 local HandlerSearch = require 'HandlerSearch'
@@ -210,9 +212,21 @@ end
 
 addLog("PluginInfoProvider loaded")
 
-local PluginInfoProvider = {}
+local PluginInfoProvider = {
+    startServer = startServer,
+    stopServer = stopServer,
+}
 
 function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
+    local prefs = LrPrefs.prefsForPlugin()
+    if prefs.autoStartServer == nil then
+        prefs.autoStartServer = true
+    end
+    propertyTable.autoStartServer = prefs.autoStartServer
+    propertyTable:addObserver('autoStartServer', function(_, _, value)
+        prefs.autoStartServer = value
+    end)
+
     local statusText = "=== Lightroom MCP Status ===\n\n"
     statusText = statusText .. "Running: " .. tostring(pluginState.running) .. "\n"
     statusText = statusText .. "Request socket connected: " .. tostring(pluginState.receiveConnected) .. "\n"
@@ -235,6 +249,10 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
                 fill_horizontal = 1,
                 width_in_chars = 70,
                 height_in_lines = 25,
+            },
+            f:checkbox {
+                title = "Auto-start server on Lightroom launch",
+                value = LrView.bind('autoStartServer'),
             },
             f:row {
                 f:push_button {

--- a/plugin/LightroomMCP.lrplugin/PluginInit.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInit.lua
@@ -1,0 +1,17 @@
+local LrPrefs = import 'LrPrefs'
+local LrTasks = import 'LrTasks'
+
+local PluginInfoProvider = require 'PluginInfoProvider'
+
+local prefs = LrPrefs.prefsForPlugin()
+local autoStart = prefs.autoStartServer
+if autoStart == nil then
+    autoStart = true
+    prefs.autoStartServer = true
+end
+
+if autoStart then
+    LrTasks.startAsyncTask(function()
+        PluginInfoProvider.startServer()
+    end)
+end


### PR DESCRIPTION
## Motivation

Closes #27. Every Lightroom session today requires a manual click on **Start Server** in Plug-in Manager. This adds friction for daily use.

## Implementation information

- Re-add `plugin/LightroomMCP.lrplugin/PluginInit.lua`. Reads `LrPrefs.prefsForPlugin().autoStartServer` (default `true`, seeded on first run) and calls `PluginInfoProvider.startServer()` from an async task.
- Wire `LrInitPlugin = 'PluginInit.lua'` in `Info.lua` so Lightroom invokes the init module on plugin load.
- Expose `startServer` / `stopServer` on the `PluginInfoProvider` module so `PluginInit.lua` can reach them. `startServer()` is already idempotent (early-return on `pluginState.running`), so a UI click after auto-start is a no-op.
- Add an **Auto-start server on Lightroom launch** checkbox to the status panel. Bound to `propertyTable.autoStartServer`, which seeds from prefs and writes back via observer.
- No transport, port, or MCP-server-side changes.

Reconnect-storm and timeout-log suppression already in place from prior work — auto-start retrying against an absent MCP server will not flood the log.

## Supporting documentation

Issue #27.

> Changelog: feat(plugin): auto-start server on launch