### PR TITLE
fix(plugin): preserve sockets across reload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Copy `plugin/LightroomMCP.lrplugin/` to:
 
 Click **Start Server** in Plug-in Manager. Logs at `~/Documents/LrClassicLogs/LightroomMCP.log`.
 
-**Reload caveat**: Lightroom's "Reload Plug-in" does NOT kill the previous async task — its sockets stay bound and block new ones. Quit Lightroom (Cmd+Q) and reopen if you see "failed to open localhost:58763" after a reload.
+**Reload behaviour**: "Reload Plug-in" tears down old sockets via `_G.LightroomMCP_State` and rebinds within ~2s. If you still see "failed to open localhost:58763", the previous async task is wedged — quit Lightroom (Cmd+Q) and reopen.
 
 ## Conventions
 

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -22,7 +22,22 @@ logger:enable("logfile")
 local REQUEST_PORT = 58763  -- plugin RECEIVES requests here (server in 'receive' mode)
 local RESPONSE_PORT = 58764 -- plugin SENDS responses here (server in 'send' mode)
 
-local pluginState = {
+-- State on _G so it survives "Reload Plug-in" within the same Lua state.
+-- The previous async task closes over this same table, so flipping its
+-- `running` flag here makes the old monitor loop exit on its next tick.
+if _G.LightroomMCP_State and _G.LightroomMCP_State.running then
+    local old = _G.LightroomMCP_State
+    logger:info("Reload detected - stopping previous server instance")
+    old.running = false
+    if old.requestSocket then
+        pcall(function() old.requestSocket:close() end)
+    end
+    if old.responseSocket then
+        pcall(function() old.responseSocket:close() end)
+    end
+end
+
+_G.LightroomMCP_State = {
     running = false,
     requestSocket = nil,
     responseSocket = nil,
@@ -32,6 +47,8 @@ local pluginState = {
     lastEvent = nil,
     log = {},
 }
+
+local pluginState = _G.LightroomMCP_State
 
 local function addLog(msg)
     table.insert(pluginState.log, os.date("%H:%M:%S") .. " - " .. msg)
@@ -194,6 +211,12 @@ local function startServer()
         end
 
         addLog("Server loop exiting")
+        if pluginState.requestSocket then
+            pcall(function() pluginState.requestSocket:close() end)
+        end
+        if pluginState.responseSocket then
+            pcall(function() pluginState.responseSocket:close() end)
+        end
         pluginState.requestSocket = nil
         pluginState.responseSocket = nil
         pluginState.sendConnected = false


### PR DESCRIPTION
## Motivation

Closes #28. Lightroom's "Reload Plug-in" re-executes Lua but does not kill
the previous async task. Old `LrSocket` instances stay bound on 58763/58764
and the new module load gets a fresh `pluginState` table, losing the handle
to the previous instance — so the new bind fails with "failed to open
localhost:58763" until the user quits Lightroom.

> Changelog: fix(plugin): preserve sockets across reload

## Implementation information

- Park state on `_G.LightroomMCP_State` so it survives module reloads
  within the same Lua state. The previous async task closes over the same
  table, so flipping `running = false` here makes the old monitor loop
  exit on its next 0.2s tick.
- On reload, also call `:close()` on the stashed sockets to release ports
  immediately, avoiding the GC race against the new bind.
- Mirror the close in the server-loop cleanup so Stop Server is symmetric
  (no port linger on a clean stop either).
- `PluginInit.lua` is unchanged: bootstrap teardown runs synchronously at
  `require` time, before the auto-start async fires.
- `_G` field access is fine for luacheck (Lua 5.4 standard global, no new
  declaration needed). `.luacheckrc` untouched.

Alternative considered: `LrShutdownPlugin` hook — Lightroom does not
invoke it on Reload Plug-in, only on quit, so it would not solve the case
in the issue.

CLAUDE.md reload caveat updated to reflect the new behaviour.

## Supporting documentation

- Issue Automaat/lightroom-mcp#28