### PR TITLE
feat(security): token handshake on sockets

### DIFF
--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -46,9 +46,19 @@ _G.LightroomMCP_State = {
     requestsProcessed = 0,
     lastEvent = nil,
     log = {},
+    token = nil,
+    authenticated = false,
 }
 
 local pluginState = _G.LightroomMCP_State
+
+local function tokenDir()
+    return LrPathUtils.child(LrPathUtils.getStandardFilePath("home"), ".config")
+end
+
+local function tokenFilePath()
+    return LrPathUtils.child(LrPathUtils.child(tokenDir(), "lightroom-mcp"), "token")
+end
 
 local function addLog(msg)
     table.insert(pluginState.log, os.date("%H:%M:%S") .. " - " .. msg)
@@ -56,6 +66,30 @@ local function addLog(msg)
         table.remove(pluginState.log, 1)
     end
     logger:info(msg)
+end
+
+local function generateToken()
+    -- Two UUIDs (32 hex chars each after stripping dashes) → 256 bits of entropy.
+    local u1 = LrUUID.generateUUID():gsub("-", "")
+    local u2 = LrUUID.generateUUID():gsub("-", "")
+    return (u1 .. u2):lower()
+end
+
+local function writeTokenFile(token)
+    local dir = LrPathUtils.child(tokenDir(), "lightroom-mcp")
+    LrFileUtils.createAllDirectories(dir)
+    local path = tokenFilePath()
+    local fh, openErr = io.open(path, "w")
+    if not fh then
+        addLog("Token write failed: " .. tostring(openErr))
+        return false
+    end
+    fh:write(token)
+    fh:close()
+    if not WIN_ENV then
+        os.execute('chmod 600 "' .. path .. '"')
+    end
+    return true
 end
 
 local DISPATCH = {
@@ -105,6 +139,21 @@ local function handleRequest(message)
         return
     end
 
+    if not pluginState.authenticated then
+        if request.hello and request.hello == pluginState.token then
+            pluginState.authenticated = true
+            addLog("Client authenticated")
+        else
+            addLog("Auth failed - dropping client")
+            if pluginState.requestSocket then
+                pcall(function() pluginState.requestSocket:close() end)
+            end
+            pluginState.receiveConnected = false
+            pluginState.requestNeedsReconnect = true
+        end
+        return
+    end
+
     local id = request.id
     local action = request.action
     local params = request.params or {}
@@ -132,6 +181,12 @@ local function startServer()
         return
     end
 
+    pluginState.token = generateToken()
+    pluginState.authenticated = false
+    if writeTokenFile(pluginState.token) then
+        addLog("Token written to " .. tokenFilePath())
+    end
+
     pluginState.running = true
     addLog("Starting LrSocket servers")
 
@@ -143,6 +198,7 @@ local function startServer()
             mode = "receive",
             onConnected = function()
                 pluginState.receiveConnected = true
+                pluginState.authenticated = false
                 addLog("REQUEST socket connected")
             end,
             onMessage = function(_, message)
@@ -152,6 +208,7 @@ local function startServer()
             end,
             onClosed = function()
                 pluginState.receiveConnected = false
+                pluginState.authenticated = false
                 pluginState.requestNeedsReconnect = true
             end,
             onError = function(_, err)
@@ -163,6 +220,7 @@ local function startServer()
                     end
                 else
                     pluginState.receiveConnected = false
+                    pluginState.authenticated = false
                     pluginState.requestNeedsReconnect = true
                     addLog("REQUEST socket error: " .. errStr)
                 end
@@ -221,6 +279,8 @@ local function startServer()
         pluginState.responseSocket = nil
         pluginState.sendConnected = false
         pluginState.receiveConnected = false
+        pluginState.authenticated = false
+        pluginState.token = nil
     end)
 end
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,12 +9,31 @@ import {
 import { PluginSocket } from "./plugin-socket.js";
 import { Dispatcher } from "./dispatcher.js";
 import { createCallToolHandler } from "./tool-handler.js";
+import { readToken, tokenFilePath } from "./token.js";
 
 const REQUEST_PORT = 58763; // plugin listens here, server writes commands
 const RESPONSE_PORT = 58764; // plugin listens here, server reads responses
 const REQUEST_TIMEOUT_MS = 30_000;
 
-const requestSocket = new PluginSocket({ port: REQUEST_PORT, label: "request" });
+try {
+  readToken();
+} catch (err) {
+  console.error((err as Error).message);
+  process.exit(1);
+}
+
+const requestSocket = new PluginSocket({
+  port: REQUEST_PORT,
+  label: "request",
+  onConnect: () => {
+    try {
+      const token = readToken();
+      requestSocket.send(JSON.stringify({ hello: token }));
+    } catch (err) {
+      console.error(`[request] token read failed: ${(err as Error).message}`);
+    }
+  },
+});
 const dispatcher = new Dispatcher({
   send: (line) => requestSocket.send(line),
   timeoutMs: REQUEST_TIMEOUT_MS,
@@ -310,6 +329,7 @@ async function main() {
   await server.connect(transport);
   console.error("Lightroom MCP server running on stdio");
   console.error(`Connecting to plugin: request :${REQUEST_PORT}, response :${RESPONSE_PORT}`);
+  console.error(`Token file: ${tokenFilePath()}`);
 }
 
 main().catch((error) => {

--- a/server/src/plugin-socket.ts
+++ b/server/src/plugin-socket.ts
@@ -6,6 +6,7 @@ export interface PluginSocketOptions {
   host?: string;
   reconnectDelayMs?: number;
   onLine?: (line: string) => void;
+  onConnect?: () => void;
   log?: (msg: string) => void;
 }
 
@@ -21,6 +22,7 @@ export class PluginSocket {
   private readonly label: string;
   private readonly reconnectDelayMs: number;
   private readonly onLine?: (line: string) => void;
+  private readonly onConnect?: () => void;
   private readonly log: (msg: string) => void;
 
   constructor(opts: PluginSocketOptions) {
@@ -29,6 +31,7 @@ export class PluginSocket {
     this.host = opts.host ?? "127.0.0.1";
     this.reconnectDelayMs = opts.reconnectDelayMs ?? 1000;
     this.onLine = opts.onLine;
+    this.onConnect = opts.onConnect;
     this.log = opts.log ?? ((msg: string) => console.error(msg));
   }
 
@@ -41,6 +44,7 @@ export class PluginSocket {
     sock.on("connect", () => {
       this.connected = true;
       this.log(`[${this.label}] connected to ${this.host}:${this.port}`);
+      this.onConnect?.();
     });
 
     sock.on("data", (chunk: string) => {

--- a/server/src/token.ts
+++ b/server/src/token.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export function tokenFilePath(): string {
+  return (
+    process.env.LIGHTROOM_MCP_TOKEN_PATH ??
+    path.join(os.homedir(), ".config", "lightroom-mcp", "token")
+  );
+}
+
+export function readToken(): string {
+  const p = tokenFilePath();
+  let raw: string;
+  try {
+    raw = fs.readFileSync(p, "utf8");
+  } catch {
+    throw new Error(
+      `Lightroom MCP token file not found at ${p}. ` +
+        `Open Lightroom and click 'Start Server' in Plug-in Manager to generate one.`,
+    );
+  }
+  const token = raw.trim();
+  if (!token) throw new Error(`Token file ${p} is empty`);
+  return token;
+}

--- a/server/tests/plugin-socket.test.ts
+++ b/server/tests/plugin-socket.test.ts
@@ -123,6 +123,42 @@ describe('PluginSocket', () => {
     expect(connectionCount).toBeGreaterThanOrEqual(2);
   });
 
+  it('fires onConnect after connecting; first send goes out before later sends', async () => {
+    const received: string[] = [];
+    server = net.createServer((conn) => {
+      serverConn = conn;
+      let buf = '';
+      conn.setEncoding('utf8');
+      conn.on('data', (chunk: string) => {
+        buf += chunk;
+        let idx;
+        while ((idx = buf.indexOf('\n')) !== -1) {
+          received.push(buf.slice(0, idx));
+          buf = buf.slice(idx + 1);
+        }
+      });
+    });
+    await new Promise<void>((resolve) => server!.listen(port, '127.0.0.1', () => resolve()));
+
+    socket = new PluginSocket({
+      port,
+      label: 'test',
+      reconnectDelayMs: 50,
+      log: () => {},
+      onConnect: () => {
+        socket!.send('{"hello":"tok"}');
+      },
+    });
+    socket.connect();
+
+    await waitFor(() => socket!.isConnected());
+    expect(socket.send('{"id":"a","action":"ping"}')).toBe(true);
+
+    await waitFor(() => received.length >= 2);
+    expect(received[0]).toBe('{"hello":"tok"}');
+    expect(received[1]).toBe('{"id":"a","action":"ping"}');
+  });
+
   it('stop() prevents further reconnects', async () => {
     let connectionCount = 0;
     server = net.createServer((conn) => {

--- a/server/tests/token.test.ts
+++ b/server/tests/token.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readToken, tokenFilePath } from '../src/token.js';
+
+describe('token', () => {
+  let tmpDir: string;
+  let tmpFile: string;
+  const originalEnv = process.env.LIGHTROOM_MCP_TOKEN_PATH;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lr-mcp-token-'));
+    tmpFile = path.join(tmpDir, 'token');
+    process.env.LIGHTROOM_MCP_TOKEN_PATH = tmpFile;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.LIGHTROOM_MCP_TOKEN_PATH;
+    else process.env.LIGHTROOM_MCP_TOKEN_PATH = originalEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads and trims the token file', () => {
+    fs.writeFileSync(tmpFile, '  abcdef123\n');
+    expect(readToken()).toBe('abcdef123');
+  });
+
+  it('throws with the path when the file is missing', () => {
+    expect(() => readToken()).toThrow(tmpFile);
+  });
+
+  it('throws when the file is empty', () => {
+    fs.writeFileSync(tmpFile, '   \n');
+    expect(() => readToken()).toThrow(/empty/);
+  });
+
+  it('respects LIGHTROOM_MCP_TOKEN_PATH override', () => {
+    expect(tokenFilePath()).toBe(tmpFile);
+  });
+
+  it('falls back to ~/.config/lightroom-mcp/token without override', () => {
+    delete process.env.LIGHTROOM_MCP_TOKEN_PATH;
+    expect(tokenFilePath()).toBe(
+      path.join(os.homedir(), '.config', 'lightroom-mcp', 'token'),
+    );
+  });
+});


### PR DESCRIPTION
## Motivation

Plugin binds 127.0.0.1:58763/58764 with no auth — any local process can connect, send tool calls, and modify the catalog. Issue #29 calls for a shared-secret handshake to drop foreign clients.

## Implementation information

- Plugin generates a 64-hex-char token from two `LrUUID.generateUUID()` calls at server start, writes `~/.config/lightroom-mcp/token` (chmod 600 on Unix), and gates `handleRequest` until a `{"hello":"<token>"}` frame arrives. Mismatch closes the request socket and triggers reconnect.
- Server reads the same file at startup (fails fast with a clear message if missing) and on every connect, then sends the hello as the first frame via a new `PluginSocket.onConnect` hook. Re-reading on each connect lets plugin restarts roll the token without restarting the MCP server.
- Response socket (LrSocket `mode='send'`) stays unauth'd by design: it has no `onMessage` so the plugin cannot validate clients. Information disclosure of responses is acceptable risk per the issue scope ("drop foreign requests", not "encrypt traffic").
- Override token path with `LIGHTROOM_MCP_TOKEN_PATH` (used by tests).

## Supporting documentation

Closes #29