### PR TITLE
ci(actions): add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Explicit version (e.g. 0.3.0). Leave blank to auto-bump.'
+        required: false
+        type: string
+      bump:
+        description: 'Auto-bump level when version is blank'
+        required: false
+        type: choice
+        default: minor
+        options: [patch, minor, major]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & publish release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            CURRENT=$(node -p "require('./server/package.json').version")
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            case "$INPUT_BUMP" in
+              major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR+1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH+1)) ;;
+              *) echo "invalid bump: $INPUT_BUMP" >&2; exit 1 ;;
+            esac
+            VERSION="$MAJOR.$MINOR.$PATCH"
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "invalid version: $VERSION" >&2; exit 1
+          fi
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          {
+            echo "VERSION=$VERSION"
+            echo "MAJOR=$MAJOR"
+            echo "MINOR=$MINOR"
+            echo "PATCH=$PATCH"
+          } >> "$GITHUB_ENV"
+          echo "Resolved version: $VERSION"
+
+      - name: Fail if tag already exists
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "tag v$VERSION already exists" >&2; exit 1
+          fi
+
+      - name: Bump server package.json
+        working-directory: server
+        run: npm version --no-git-tag-version "$VERSION"
+
+      - name: Bump server runtime version string
+        run: |
+          sed -i -E 's/version: "[0-9]+\.[0-9]+\.[0-9]+"/version: "'"$VERSION"'"/' server/src/index.ts
+          grep -q "version: \"$VERSION\"" server/src/index.ts
+
+      - name: Bump plugin Info.lua
+        run: |
+          sed -i -E 's/VERSION = \{ major=[0-9]+, minor=[0-9]+, revision=[0-9]+, build=[0-9]+ \}/VERSION = { major='"$MAJOR"', minor='"$MINOR"', revision='"$PATCH"', build=0 }/' plugin/LightroomMCP.lrplugin/Info.lua
+          grep -q "major=$MAJOR, minor=$MINOR, revision=$PATCH" plugin/LightroomMCP.lrplugin/Info.lua
+
+      - name: Install dependencies
+        working-directory: server
+        run: npm ci
+
+      - name: Type check
+        working-directory: server
+        run: npx tsc --noEmit
+
+      - name: Build server
+        working-directory: server
+        run: npm run build
+
+      - name: Pack server tarball
+        working-directory: server
+        run: npm pack
+
+      - name: Zip plugin bundle
+        working-directory: plugin
+        run: zip -r ../LightroomMCP.lrplugin.zip LightroomMCP.lrplugin
+
+      - name: Commit, tag, push
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add server/package.json server/package-lock.json server/src/index.ts plugin/LightroomMCP.lrplugin/Info.lua
+          git commit -m "chore(release): v$VERSION"
+          git tag "v$VERSION"
+          git push origin HEAD:main
+          git push origin "v$VERSION"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v$VERSION" \
+            LightroomMCP.lrplugin.zip \
+            "server/lightroom-mcp-server-$VERSION.tgz" \
+            --title "v$VERSION" \
+            --generate-notes


### PR DESCRIPTION
## Motivation

Closes #30. Currently users install by cloning the repo. A downloadable plugin .zip and server .tgz attached to GitHub releases is a much smoother first-run experience.

## Implementation information

New workflow `.github/workflows/release.yml`, manually triggered via **Actions → Release → Run workflow**.

Inputs:
- `version` (optional): explicit version like `0.3.0`
- `bump` (optional, default `minor`): `patch` / `minor` / `major` — used when `version` is blank

Steps:
1. Resolve version (explicit input wins; otherwise read `server/package.json` and bump)
2. Fail fast if `vX.Y.Z` tag already exists
3. Bump three places to one shared version: `server/package.json` (via `npm version`), `server/src/index.ts` runtime string, `plugin/LightroomMCP.lrplugin/Info.lua` VERSION table
4. `npm ci`, `tsc --noEmit`, `npm run build`, `npm pack` → `lightroom-mcp-server-X.Y.Z.tgz`
5. `zip -r LightroomMCP.lrplugin.zip LightroomMCP.lrplugin` from `plugin/`
6. Commit bump as `github-actions[bot]`, tag `vX.Y.Z`, push to `main`
7. `gh release create` with both artifacts + auto-generated notes

Concurrency group `release` prevents overlapping runs racing on the tag. `permissions: contents: write` covers push + tag + release.

Alternatives considered:
- **Tag-push trigger** — original issue text. Skipped because user wants manual control + auto-bump.
- **npm publish** — issue says optional; skipped, easy to add later.
- **Separate plugin/server versions** — kept in sync to avoid the current 0.1.0 vs 0.2.0 drift.

Validated locally: `actionlint` passes, bump logic dry-run produced `0.2.0 → 0.3.0` correctly across all three files.

## Supporting documentation

Issue #30.

> Changelog: ci(actions): add manual release workflow