### PR TITLE
feat(config): make transport ports configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ MCP server bridging Claude to Adobe Lightroom Classic.
 
 Plugin opens **two LrSocket binds** as servers; MCP server connects to both.
 
-- Plugin :58763 in `mode='receive'` — server writes line-delimited JSON requests
-- Plugin :58764 in `mode='send'` — server reads line-delimited JSON responses
+- Plugin :58763 (default) in `mode='receive'` — server writes line-delimited JSON requests
+- Plugin :58764 (default) in `mode='send'` — server reads line-delimited JSON responses
 - Frame: `\n` terminator on every message (LrSocket buffers until newline)
 - Plugin allows **one client per port at a time**. MCP server holds a persistent connection.
 - `LrSocket.bind` in `mode='receive'` has a 10s no-client timeout that fires `onError`. Plugin auto-calls `:reconnect()` from a monitor loop in response. Reconnect storms are prevented by setting flags in callbacks and acting on them in the loop (never `:reconnect()` synchronously from `onError`).
@@ -62,4 +62,4 @@ Click **Start Server** in Plug-in Manager. Logs at `~/Documents/LrClassicLogs/Li
 - TS strict mode on. ESM imports must include `.js` extension (NodeNext).
 - New Lua handlers: add file under `plugin/LightroomMCP.lrplugin/Handler*.lua`, register in `DISPATCH` table in `PluginInfoProvider.lua`, declare any new LR globals in `.luacheckrc`.
 - New MCP tool: add schema in `server/src/index.ts` `ListToolsRequestSchema` handler **and** add a `DISPATCH` entry in `PluginInfoProvider.lua`.
-- Ports `58763` (request) and `58764` (response) are hardcoded both sides — change in lockstep.
+- Default ports `58763` (request) / `58764` (response). Server overrides via env vars `LIGHTROOM_MCP_REQUEST_PORT` / `LIGHTROOM_MCP_RESPONSE_PORT` (parsed in `server/src/ports.ts`); plugin overrides via Plug-in Manager fields stored in `LrPrefs` (`requestPort` / `responsePort`). Both sides must agree — change in lockstep.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ Replace `/Users/YOUR_USERNAME/` with your actual path.
 
 Restart Claude Desktop to load the MCP server.
 
+## Configuration
+
+Default ports: `58763` (request) / `58764` (response). To override (e.g. port conflict, multiple Lightroom instances), set both sides to matching values:
+
+- **Server**: env vars `LIGHTROOM_MCP_REQUEST_PORT` / `LIGHTROOM_MCP_RESPONSE_PORT` (set them in your Claude Desktop config under `env`, or in the shell that launches the server).
+- **Plugin**: open **File > Plug-in Manager > Lightroom MCP** and edit the **Request port** / **Response port** fields. Stop and Start the server for the change to take effect.
+
+Both sides must agree, otherwise the server cannot connect.
+
 ## Usage Examples
 
 ### Search Photos
@@ -243,7 +252,7 @@ Check Claude Desktop logs:
 - macOS: `~/Library/Logs/Claude/mcp*.log`
 
 Common issues:
-- **`failed to open localhost:58763` after Reload Plug-in** — old async task still owns the port; Quit Lightroom (Cmd+Q) and reopen.
+- **`failed to open localhost:58763` (or your configured port) after Reload Plug-in** — old async task still owns the port; Quit Lightroom (Cmd+Q) and reopen.
 - **MCP server reports "plugin not connected"** — click **Start Server** in Plug-in Manager; server reconnects automatically within 1s.
 - **Timeout errors** — handler may be stuck on a slow `getAllPhotos()` scan; check Show Status for `Last event` timestamp.
 

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -19,8 +19,21 @@ local HandlerDevelop = require 'HandlerDevelop'
 local logger = LrLogger('LightroomMCP')
 logger:enable("logfile")
 
-local REQUEST_PORT = 58763  -- plugin RECEIVES requests here (server in 'receive' mode)
-local RESPONSE_PORT = 58764 -- plugin SENDS responses here (server in 'send' mode)
+local DEFAULT_REQUEST_PORT = 58763
+local DEFAULT_RESPONSE_PORT = 58764
+
+local function validPort(n)
+    return type(n) == "number" and n == math.floor(n) and n >= 1 and n <= 65535
+end
+
+local function readPortPrefs()
+    local prefs = LrPrefs.prefsForPlugin()
+    local req = tonumber(prefs.requestPort)
+    local res = tonumber(prefs.responsePort)
+    if not validPort(req) then req = DEFAULT_REQUEST_PORT end
+    if not validPort(res) then res = DEFAULT_RESPONSE_PORT end
+    return req, res
+end
 
 -- State on _G so it survives "Reload Plug-in" within the same Lua state.
 -- The previous async task closes over this same table, so flipping its
@@ -187,6 +200,10 @@ local function startServer()
         addLog("Token written to " .. tokenFilePath())
     end
 
+    local requestPort, responsePort = readPortPrefs()
+    pluginState.requestPort = requestPort
+    pluginState.responsePort = responsePort
+
     pluginState.running = true
     addLog("Starting LrSocket servers")
 
@@ -194,7 +211,7 @@ local function startServer()
         pluginState.requestSocket = LrSocket.bind {
             functionContext = context,
             plugin = _PLUGIN,
-            port = REQUEST_PORT,
+            port = requestPort,
             mode = "receive",
             onConnected = function()
                 pluginState.receiveConnected = true
@@ -226,12 +243,12 @@ local function startServer()
                 end
             end,
         }
-        addLog("REQUEST bound on " .. REQUEST_PORT)
+        addLog("REQUEST bound on " .. requestPort)
 
         pluginState.responseSocket = LrSocket.bind {
             functionContext = context,
             plugin = _PLUGIN,
-            port = RESPONSE_PORT,
+            port = responsePort,
             mode = "send",
             onConnected = function()
                 pluginState.sendConnected = true
@@ -254,7 +271,7 @@ local function startServer()
                 end
             end,
         }
-        addLog("RESPONSE bound on " .. RESPONSE_PORT)
+        addLog("RESPONSE bound on " .. responsePort)
 
         while pluginState.running do
             if pluginState.requestNeedsReconnect and pluginState.requestSocket then
@@ -310,14 +327,29 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
         prefs.autoStartServer = value
     end)
 
+    local cfgRequestPort, cfgResponsePort = readPortPrefs()
+    propertyTable.requestPort = cfgRequestPort
+    propertyTable.responsePort = cfgResponsePort
+    propertyTable:addObserver('requestPort', function(_, _, value)
+        local n = tonumber(value)
+        if validPort(n) then prefs.requestPort = n end
+    end)
+    propertyTable:addObserver('responsePort', function(_, _, value)
+        local n = tonumber(value)
+        if validPort(n) then prefs.responsePort = n end
+    end)
+
+    local activeRequest = pluginState.requestPort or cfgRequestPort
+    local activeResponse = pluginState.responsePort or cfgResponsePort
+
     local statusText = "=== Lightroom MCP Status ===\n\n"
     statusText = statusText .. "Running: " .. tostring(pluginState.running) .. "\n"
     statusText = statusText .. "Request socket connected: " .. tostring(pluginState.receiveConnected) .. "\n"
     statusText = statusText .. "Response socket connected: " .. tostring(pluginState.sendConnected) .. "\n"
     statusText = statusText .. "Last event: " .. (pluginState.lastEvent or "Never") .. "\n"
     statusText = statusText .. "Requests processed: " .. pluginState.requestsProcessed .. "\n"
-    statusText = statusText .. "Request port: " .. REQUEST_PORT .. " (mode=receive)\n"
-    statusText = statusText .. "Response port: " .. RESPONSE_PORT .. " (mode=send)\n"
+    statusText = statusText .. "Request port: " .. activeRequest .. " (mode=receive)\n"
+    statusText = statusText .. "Response port: " .. activeResponse .. " (mode=send)\n"
     statusText = statusText .. "\nRecent logs:\n"
     local startIdx = math.max(1, #pluginState.log - 15)
     for i = startIdx, #pluginState.log do
@@ -336,6 +368,34 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
             f:checkbox {
                 title = "Auto-start server on Lightroom launch",
                 value = LrView.bind('autoStartServer'),
+            },
+            f:row {
+                f:static_text { title = "Request port:", width = 110 },
+                f:edit_text {
+                    value = LrView.bind('requestPort'),
+                    width_in_chars = 7,
+                    precision = 0,
+                    min = 1,
+                    max = 65535,
+                },
+                f:static_text { title = "(default 58763)" },
+            },
+            f:row {
+                f:static_text { title = "Response port:", width = 110 },
+                f:edit_text {
+                    value = LrView.bind('responsePort'),
+                    width_in_chars = 7,
+                    precision = 0,
+                    min = 1,
+                    max = 65535,
+                },
+                f:static_text { title = "(default 58764)" },
+            },
+            f:static_text {
+                title = "Port changes apply on next Start. Server env vars must match: LIGHTROOM_MCP_REQUEST_PORT / LIGHTROOM_MCP_RESPONSE_PORT.",
+                fill_horizontal = 1,
+                width_in_chars = 70,
+                height_in_lines = 2,
             },
             f:row {
                 f:push_button {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,12 +10,15 @@ import { PluginSocket } from "./plugin-socket.js";
 import { Dispatcher } from "./dispatcher.js";
 import { createCallToolHandler } from "./tool-handler.js";
 import { readToken, tokenFilePath } from "./token.js";
+import { requestPort, responsePort } from "./ports.js";
 
-const REQUEST_PORT = 58763; // plugin listens here, server writes commands
-const RESPONSE_PORT = 58764; // plugin listens here, server reads responses
 const REQUEST_TIMEOUT_MS = 30_000;
 
+let REQUEST_PORT: number;
+let RESPONSE_PORT: number;
 try {
+  REQUEST_PORT = requestPort();
+  RESPONSE_PORT = responsePort();
   readToken();
 } catch (err) {
   console.error((err as Error).message);

--- a/server/src/ports.ts
+++ b/server/src/ports.ts
@@ -1,0 +1,31 @@
+const DEFAULT_REQUEST_PORT = 58763;
+const DEFAULT_RESPONSE_PORT = 58764;
+
+function parsePort(raw: string | undefined, fallback: number, name: string): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const trimmed = raw.trim();
+  if (!/^[0-9]+$/.test(trimmed)) {
+    throw new Error(`${name} must be a positive integer 1-65535, got "${raw}"`);
+  }
+  const n = Number(trimmed);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(`${name} must be a positive integer 1-65535, got "${raw}"`);
+  }
+  return n;
+}
+
+export function requestPort(): number {
+  return parsePort(
+    process.env.LIGHTROOM_MCP_REQUEST_PORT,
+    DEFAULT_REQUEST_PORT,
+    "LIGHTROOM_MCP_REQUEST_PORT",
+  );
+}
+
+export function responsePort(): number {
+  return parsePort(
+    process.env.LIGHTROOM_MCP_RESPONSE_PORT,
+    DEFAULT_RESPONSE_PORT,
+    "LIGHTROOM_MCP_RESPONSE_PORT",
+  );
+}

--- a/server/tests/ports.test.ts
+++ b/server/tests/ports.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { requestPort, responsePort } from '../src/ports.js';
+
+describe('ports', () => {
+  const originalReq = process.env.LIGHTROOM_MCP_REQUEST_PORT;
+  const originalRes = process.env.LIGHTROOM_MCP_RESPONSE_PORT;
+
+  beforeEach(() => {
+    delete process.env.LIGHTROOM_MCP_REQUEST_PORT;
+    delete process.env.LIGHTROOM_MCP_RESPONSE_PORT;
+  });
+
+  afterEach(() => {
+    if (originalReq === undefined) delete process.env.LIGHTROOM_MCP_REQUEST_PORT;
+    else process.env.LIGHTROOM_MCP_REQUEST_PORT = originalReq;
+    if (originalRes === undefined) delete process.env.LIGHTROOM_MCP_RESPONSE_PORT;
+    else process.env.LIGHTROOM_MCP_RESPONSE_PORT = originalRes;
+  });
+
+  it('returns default request port when env unset', () => {
+    expect(requestPort()).toBe(58763);
+  });
+
+  it('returns default response port when env unset', () => {
+    expect(responsePort()).toBe(58764);
+  });
+
+  it('treats empty env value as unset', () => {
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = '';
+    process.env.LIGHTROOM_MCP_RESPONSE_PORT = '   ';
+    expect(requestPort()).toBe(58763);
+    expect(responsePort()).toBe(58764);
+  });
+
+  it('accepts a valid override', () => {
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = '12345';
+    process.env.LIGHTROOM_MCP_RESPONSE_PORT = '12346';
+    expect(requestPort()).toBe(12345);
+    expect(responsePort()).toBe(12346);
+  });
+
+  it('trims surrounding whitespace', () => {
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = '  9000  ';
+    expect(requestPort()).toBe(9000);
+  });
+
+  it('throws on non-numeric value', () => {
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = 'abc';
+    expect(() => requestPort()).toThrow(/LIGHTROOM_MCP_REQUEST_PORT/);
+    expect(() => requestPort()).toThrow(/abc/);
+  });
+
+  it('throws on zero', () => {
+    process.env.LIGHTROOM_MCP_RESPONSE_PORT = '0';
+    expect(() => responsePort()).toThrow(/LIGHTROOM_MCP_RESPONSE_PORT/);
+  });
+
+  it('throws on 65536', () => {
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = '65536';
+    expect(() => requestPort()).toThrow(/LIGHTROOM_MCP_REQUEST_PORT/);
+  });
+
+  it('throws on negative', () => {
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = '-1';
+    expect(() => requestPort()).toThrow(/LIGHTROOM_MCP_REQUEST_PORT/);
+  });
+
+  it('throws on float', () => {
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = '1234.5';
+    expect(() => requestPort()).toThrow(/LIGHTROOM_MCP_REQUEST_PORT/);
+  });
+
+  it('accepts boundary values', () => {
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = '1';
+    expect(requestPort()).toBe(1);
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = '65535';
+    expect(requestPort()).toBe(65535);
+  });
+});


### PR DESCRIPTION
## Motivation

Closes #31. Ports `58763` (request) / `58764` (response) are hardcoded both sides. Users with port conflicts (other apps, multiple Lightroom instances) have no escape hatch.

## Implementation information

- **Server**: new `server/src/ports.ts` reads `LIGHTROOM_MCP_REQUEST_PORT` / `LIGHTROOM_MCP_RESPONSE_PORT`, validates integer 1–65535, throws clear error otherwise. Mirrors the existing `LIGHTROOM_MCP_TOKEN_PATH` pattern in `token.ts`. `index.ts` calls them inside the same try/catch as `readToken()` so a bad env var exits cleanly with the error message.
- **Plugin**: `PluginInfoProvider.lua` adds `validPort` + `readPortPrefs` helpers backed by `LrPrefs.prefsForPlugin()`. `startServer` reads fresh values per call (so a UI change applies on next Start). Plug-in Manager UI gains two `f:edit_text` rows wired to prefs via observers, plus a help line documenting the matching server env-var names.
- **Defaults preserved**: `58763` / `58764` so existing setups keep working with no config.
- **Tests**: 11 new jest cases covering defaults, override, empty/whitespace, non-numeric, 0, 65536, negative, float, boundaries.
- **Docs**: `CLAUDE.md` and `README.md` updated; new "Configuration" section in README.

## Supporting documentation

Issue: #31

> Changelog: feat(config): make transport ports configurable