### PR TITLE
fix(plugin): harden dual-port bridge plumbing

### DIFF
--- a/manual-test.mjs
+++ b/manual-test.mjs
@@ -6,15 +6,34 @@
 //   node manual-test.mjs list_collections
 //   node manual-test.mjs search_photos '{"rating":5}'
 
+import fs from "node:fs";
 import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 
-const REQUEST_PORT = 58763;
-const RESPONSE_PORT = 58764;
+const REQUEST_PORT = Number(process.env.LIGHTROOM_MCP_REQUEST_PORT ?? 58763);
+const RESPONSE_PORT = Number(process.env.LIGHTROOM_MCP_RESPONSE_PORT ?? 58764);
+const TOKEN_PATH =
+  process.env.LIGHTROOM_MCP_TOKEN_PATH ??
+  path.join(os.homedir(), ".config", "lightroom-mcp", "token");
 const TIMEOUT_MS = 30_000;
 
 const action = process.argv[2] ?? "list_collections";
 const params = process.argv[3] ? JSON.parse(process.argv[3]) : {};
 const id = `manual_${Date.now()}`;
+
+let token;
+try {
+  token = fs.readFileSync(TOKEN_PATH, "utf8").trim();
+} catch (err) {
+  console.error(`token read failed at ${TOKEN_PATH}: ${err.message}`);
+  console.error("start the plugin in Lightroom first");
+  process.exit(1);
+}
+if (!token) {
+  console.error(`token file ${TOKEN_PATH} is empty`);
+  process.exit(1);
+}
 
 function connect(port, label) {
   return new Promise((resolve, reject) => {
@@ -54,6 +73,8 @@ const responsePromise = new Promise((resolve, reject) => {
   });
   respSock.on("close", () => reject(new Error("response socket closed")));
 });
+
+reqSock.write(JSON.stringify({ hello: token }) + "\n");
 
 const payload = JSON.stringify({ id, action, params });
 console.log(`>>> ${payload}`);

--- a/plugin/LightroomMCP.lrplugin/HandlerExport.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerExport.lua
@@ -36,11 +36,14 @@ function ExportHandler.exportPhotos(args)
             error("No photos found to export")
         end
 
-        -- Prepare export settings
+        -- destinationType=specificFolder makes LR honour
+        -- LR_export_destinationPathPrefix; sourceFolder ignores it and
+        -- writes next to the original. LR_format is set in the
+        -- format-specific block below.
         local exportSettings = {
-            LR_export_destinationType = 'sourceFolder',
+            LR_export_destinationType = 'specificFolder',
             LR_export_destinationPathPrefix = args.destination,
-            LR_format = args.format or 'JPEG',
+            LR_export_useSubfolder = false,
             LR_jpeg_quality = args.quality or 90,
         }
 

--- a/plugin/LightroomMCP.lrplugin/HandlerOrganization.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerOrganization.lua
@@ -71,11 +71,15 @@ function OrganizationHandler.setRating(args)
     local catalog = LrApplication.activeCatalog()
     local updatedCount = 0
 
+    -- LrSDK rejects literal 0 on the rating field; nil means "no rating".
+    local ratingValue = args.rating
+    if ratingValue == 0 then ratingValue = nil end
+
     catalog:withWriteAccessDo("Set Rating", function()
         local resolved = PhotoLookup.resolveMany(catalog, args.photo_ids)
         for _, entry in ipairs(resolved) do
             if entry.photo then
-                entry.photo:setRawMetadata('rating', args.rating)
+                entry.photo:setRawMetadata('rating', ratingValue)
                 updatedCount = updatedCount + 1
             end
         end

--- a/plugin/LightroomMCP.lrplugin/Info.lua
+++ b/plugin/LightroomMCP.lrplugin/Info.lua
@@ -11,4 +11,17 @@ return {
 
     LrPluginInfoProvider = 'PluginInfoProvider.lua',
     LrInitPlugin = 'PluginInit.lua',
+    -- LrForceInitPlugin forces eager load on Lr launch, but ONLY if the
+    -- plugin also exposes at least one menu item — see LrLibraryMenuItems
+    -- below. Adobe's own remote_control_socket sample uses this pattern.
+    LrForceInitPlugin = true,
+    LrShutdownPlugin = 'PluginShutdown.lua',
+    LrShutdownApp = 'PluginShutdown.lua',
+
+    LrLibraryMenuItems = {
+        {
+            title = "Lightroom MCP — Show Status",
+            file = "MenuShowStatus.lua",
+        },
+    },
 }

--- a/plugin/LightroomMCP.lrplugin/MenuShowStatus.lua
+++ b/plugin/LightroomMCP.lrplugin/MenuShowStatus.lua
@@ -1,0 +1,22 @@
+local LrDialogs = import 'LrDialogs'
+
+local state = _G.LightroomMCP_State or {}
+
+local lines = {
+    "Running: " .. tostring(state.running),
+    "Request socket connected: " .. tostring(state.receiveConnected),
+    "Response socket connected: " .. tostring(state.sendConnected),
+    "Last event: " .. tostring(state.lastEvent or "Never"),
+    "Requests processed: " .. tostring(state.requestsProcessed or 0),
+    "",
+    "Recent logs:",
+}
+
+if state.log then
+    local startIdx = math.max(1, #state.log - 30)
+    for i = startIdx, #state.log do
+        table.insert(lines, "  " .. state.log[i])
+    end
+end
+
+LrDialogs.message("Lightroom MCP Status", table.concat(lines, "\n"), "info")

--- a/plugin/LightroomMCP.lrplugin/PhotoLookup.lua
+++ b/plugin/LightroomMCP.lrplugin/PhotoLookup.lua
@@ -11,21 +11,20 @@ function PhotoLookup.resolveMany(catalog, photoIds)
         results[i] = { id = id, photo = nil }
     end
 
-    -- LrCatalog has no findPhotoByLocalIdentifier; build both indexes from
-    -- a single getAllPhotos pass. Skip the scan only if every id resolves
-    -- as a numeric local id AND we already have an index — but in practice
-    -- one scan is the cheapest correct path.
+    -- LrCatalog has no findPhotoByLocalIdentifier; one getAllPhotos pass
+    -- builds both id and path indexes. localIdentifier is numeric in
+    -- production but tests pass strings — normalize via tostring.
     local byLocalId = {}
     local byPath = {}
     for _, p in ipairs(catalog:getAllPhotos()) do
-        byLocalId[p.localIdentifier] = p
-        byPath[p:getRawMetadata('path')] = p
+        local lid = p.localIdentifier
+        if lid ~= nil then byLocalId[tostring(lid)] = p end
+        local path = p:getRawMetadata('path')
+        if path ~= nil then byPath[path] = p end
     end
 
     for i, id in ipairs(photoIds) do
-        local numId = tonumber(id)
-        local photo = nil
-        if numId then photo = byLocalId[numId] end
+        local photo = byLocalId[tostring(id)]
         if not photo then photo = byPath[id] end
         results[i].photo = photo
     end

--- a/plugin/LightroomMCP.lrplugin/PhotoLookup.lua
+++ b/plugin/LightroomMCP.lrplugin/PhotoLookup.lua
@@ -7,28 +7,27 @@ local PhotoLookup = {}
 --   results[i] = { id = inputId, photo = photoOrNil }
 function PhotoLookup.resolveMany(catalog, photoIds)
     local results = {}
-    local missingIdx = {}
-
     for i, id in ipairs(photoIds) do
-        local photo = nil
-        local numId = tonumber(id)
-        if numId then
-            photo = catalog:findPhotoByLocalIdentifier(numId)
-        end
-        results[i] = { id = id, photo = photo }
-        if not photo then
-            table.insert(missingIdx, i)
-        end
+        results[i] = { id = id, photo = nil }
     end
 
-    if #missingIdx > 0 then
-        local byPath = {}
-        for _, p in ipairs(catalog:getAllPhotos()) do
-            byPath[p:getRawMetadata('path')] = p
-        end
-        for _, idx in ipairs(missingIdx) do
-            results[idx].photo = byPath[results[idx].id]
-        end
+    -- LrCatalog has no findPhotoByLocalIdentifier; build both indexes from
+    -- a single getAllPhotos pass. Skip the scan only if every id resolves
+    -- as a numeric local id AND we already have an index — but in practice
+    -- one scan is the cheapest correct path.
+    local byLocalId = {}
+    local byPath = {}
+    for _, p in ipairs(catalog:getAllPhotos()) do
+        byLocalId[p.localIdentifier] = p
+        byPath[p:getRawMetadata('path')] = p
+    end
+
+    for i, id in ipairs(photoIds) do
+        local numId = tonumber(id)
+        local photo = nil
+        if numId then photo = byLocalId[numId] end
+        if not photo then photo = byPath[id] end
+        results[i].photo = photo
     end
 
     return results

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -5,6 +5,9 @@ local LrFunctionContext = import 'LrFunctionContext'
 local LrSocket = import 'LrSocket'
 local LrPrefs = import 'LrPrefs'
 local LrView = import 'LrView'
+local LrUUID = import 'LrUUID'
+local LrPathUtils = import 'LrPathUtils'
+local LrFileUtils = import 'LrFileUtils'
 
 local JSON = require 'JSON'
 local HandlerSearch = require 'HandlerSearch'
@@ -22,6 +25,14 @@ logger:enable("logfile")
 local DEFAULT_REQUEST_PORT = 58763
 local DEFAULT_RESPONSE_PORT = 58764
 
+-- LrSocket fires these on its accept-loop when no client is attached yet.
+-- Both are benign listen-side states, not real failures.
+local function isNoClientError(errStr)
+    if errStr == "timeout" then return true end
+    if errStr:find("failed to open", 1, true) then return true end
+    return false
+end
+
 local function validPort(n)
     return type(n) == "number" and n == math.floor(n) and n >= 1 and n <= 65535
 end
@@ -36,9 +47,14 @@ local function readPortPrefs()
 end
 
 -- State on _G so it survives "Reload Plug-in" within the same Lua state.
--- The previous async task closes over this same table, so flipping its
--- `running` flag here makes the old monitor loop exit on its next tick.
+-- This module body executes BOTH when PluginInit requires it AND when
+-- Lr loads it as the InfoProvider, so it can run twice in quick
+-- succession. We must not blow away an existing state on the second
+-- load, otherwise we end up with two pluginState tables, two LrSocket
+-- binds, two tokens, and connections land on whichever listener the
+-- kernel hands the accept to — usually the wrong one.
 if _G.LightroomMCP_State and _G.LightroomMCP_State.running then
+    -- True Reload Plug-in of a running server: tear down the old loop.
     local old = _G.LightroomMCP_State
     logger:info("Reload detected - stopping previous server instance")
     old.running = false
@@ -48,20 +64,22 @@ if _G.LightroomMCP_State and _G.LightroomMCP_State.running then
     if old.responseSocket then
         pcall(function() old.responseSocket:close() end)
     end
+    _G.LightroomMCP_State = nil
 end
 
-_G.LightroomMCP_State = {
-    running = false,
-    requestSocket = nil,
-    responseSocket = nil,
-    sendConnected = false,
-    receiveConnected = false,
-    requestsProcessed = 0,
-    lastEvent = nil,
-    log = {},
-    token = nil,
-    authenticated = false,
-}
+if not _G.LightroomMCP_State then
+    _G.LightroomMCP_State = {
+        running = false,
+        requestSocket = nil,
+        responseSocket = nil,
+        sendConnected = false,
+        receiveConnected = false,
+        requestsProcessed = 0,
+        lastEvent = nil,
+        log = {},
+        token = nil,
+    }
+end
 
 local pluginState = _G.LightroomMCP_State
 
@@ -99,9 +117,9 @@ local function writeTokenFile(token)
     end
     fh:write(token)
     fh:close()
-    if not WIN_ENV then
-        os.execute('chmod 600 "' .. path .. '"')
-    end
+    -- Lightroom's Lua sandbox has no os.execute; skip chmod. File sits in
+    -- ~/.config/lightroom-mcp/ which is user-private on macOS. Token only
+    -- gates a localhost socket, so threat is local-user only.
     return true
 end
 
@@ -122,7 +140,12 @@ local DISPATCH = {
     set_develop_settings = HandlerDevelop.setDevelopSettings,
 }
 
-local SEND_WAIT_SECONDS = 5
+-- Generous wait so the very first response after handshake doesn't get
+-- dropped while LrSocket is still settling sendConnected on the response
+-- side. Must stay below the server's dispatcher timeout (30s) so a real
+-- send-side outage still surfaces as a server-side timeout, not silent
+-- success.
+local SEND_WAIT_SECONDS = 25
 
 local function sendResponse(response)
     local waited = 0
@@ -143,30 +166,7 @@ local function sendResponse(response)
     pluginState.requestsProcessed = pluginState.requestsProcessed + 1
 end
 
-local function handleRequest(message)
-    pluginState.lastEvent = os.date("%H:%M:%S")
-
-    local parsedOk, request = pcall(function() return JSON:decode(message) end)
-    if not parsedOk or type(request) ~= "table" then
-        addLog("JSON decode failed: " .. tostring(message))
-        return
-    end
-
-    if not pluginState.authenticated then
-        if request.hello and request.hello == pluginState.token then
-            pluginState.authenticated = true
-            addLog("Client authenticated")
-        else
-            addLog("Auth failed - dropping client")
-            if pluginState.requestSocket then
-                pcall(function() pluginState.requestSocket:close() end)
-            end
-            pluginState.receiveConnected = false
-            pluginState.requestNeedsReconnect = true
-        end
-        return
-    end
-
+local function dispatchAction(request)
     local id = request.id
     local action = request.action
     local params = request.params or {}
@@ -188,6 +188,30 @@ local function handleRequest(message)
     end
 end
 
+-- Runs SYNCHRONOUSLY in onMessage. Every request must carry the current
+-- token in `hello`; we authenticate per-message so connection-state
+-- races (reload, dual-instance, reconnect) can't desync auth from the
+-- live token.
+local function consumeMessage(message)
+    pluginState.lastEvent = os.date("%H:%M:%S")
+
+    local parsedOk, request = pcall(function() return JSON:decode(message) end)
+    if not parsedOk or type(request) ~= "table" then
+        addLog("JSON decode failed: " .. tostring(message))
+        return nil
+    end
+
+    if not pluginState.token or request.hello ~= pluginState.token then
+        -- Drop silently. We CANNOT call sendResponse here: onMessage runs
+        -- in a non-yielding context and sendResponse uses LrTasks.sleep.
+        -- Server will time out, which is correct behaviour for auth fail.
+        addLog("Auth failed (token mismatch) id=" .. tostring(request.id))
+        return nil
+    end
+
+    return request
+end
+
 local function startServer()
     if pluginState.running then
         addLog("Already running")
@@ -195,7 +219,6 @@ local function startServer()
     end
 
     pluginState.token = generateToken()
-    pluginState.authenticated = false
     if writeTokenFile(pluginState.token) then
         addLog("Token written to " .. tokenFilePath())
     end
@@ -208,69 +231,96 @@ local function startServer()
     addLog("Starting LrSocket servers")
 
     LrFunctionContext.postAsyncTaskWithContext("LightroomMCPServer", function(context)
-        pluginState.requestSocket = LrSocket.bind {
-            functionContext = context,
-            plugin = _PLUGIN,
-            port = requestPort,
-            mode = "receive",
-            onConnected = function()
-                pluginState.receiveConnected = true
-                pluginState.authenticated = false
-                addLog("REQUEST socket connected")
-            end,
-            onMessage = function(_, message)
-                LrTasks.startAsyncTask(function()
-                    handleRequest(message)
-                end)
-            end,
-            onClosed = function()
-                pluginState.receiveConnected = false
-                pluginState.authenticated = false
-                pluginState.requestNeedsReconnect = true
-            end,
-            onError = function(_, err)
-                local errStr = tostring(err)
-                if errStr == "timeout" then
-                    -- listen socket timeout. Only reconnect if no active client.
-                    if not pluginState.receiveConnected then
-                        pluginState.requestNeedsReconnect = true
-                    end
-                else
-                    pluginState.receiveConnected = false
-                    pluginState.authenticated = false
-                    pluginState.requestNeedsReconnect = true
-                    addLog("REQUEST socket error: " .. errStr)
-                end
-            end,
-        }
-        addLog("REQUEST bound on " .. requestPort)
-
-        pluginState.responseSocket = LrSocket.bind {
-            functionContext = context,
-            plugin = _PLUGIN,
-            port = responsePort,
-            mode = "send",
-            onConnected = function()
-                pluginState.sendConnected = true
-                addLog("RESPONSE socket connected")
-            end,
-            onClosed = function()
-                pluginState.sendConnected = false
-                pluginState.responseNeedsReconnect = true
-            end,
-            onError = function(_, err)
-                local errStr = tostring(err)
-                if errStr == "timeout" then
-                    if not pluginState.sendConnected then
-                        pluginState.responseNeedsReconnect = true
-                    end
-                else
+        local function bindRequest()
+            return LrSocket.bind {
+                functionContext = context,
+                plugin = _PLUGIN,
+                port = requestPort,
+                mode = "receive",
+                onConnected = function()
+                    pluginState.receiveConnected = true
+                    -- New request client = new MCP session. Force a
+                    -- response-side rebind so the freshly-bound listener
+                    -- accepts THIS client's response-port TCP. LrSocket
+                    -- send-mode doesn't reliably notice client disconnect,
+                    -- so without this `sendConnected` stays true pointing
+                    -- at the prior client and :send() writes to the void.
                     pluginState.sendConnected = false
-                    pluginState.responseNeedsReconnect = true
-                    addLog("RESPONSE socket error: " .. errStr)
-                end
-            end,
-        }
+                    pluginState.responseNeedsRebind = true
+                    addLog("REQUEST socket connected")
+                end,
+                onMessage = function(_, message)
+                    local request = consumeMessage(message)
+                    if request then
+                        LrTasks.startAsyncTask(function()
+                            dispatchAction(request)
+                        end)
+                    end
+                end,
+                onClosed = function()
+                    pluginState.receiveConnected = false
+                    pluginState.requestNeedsReconnect = true
+                end,
+                onError = function(_, err)
+                    local errStr = tostring(err)
+                    if isNoClientError(errStr) then
+                        if not pluginState.receiveConnected then
+                            pluginState.requestNeedsReconnect = true
+                        end
+                    else
+                        pluginState.receiveConnected = false
+                        pluginState.requestNeedsReconnect = true
+                        addLog("REQUEST socket error: " .. errStr)
+                    end
+                end,
+            }
+        end
+
+        -- Each rebind bumps a generation. Old-listener callbacks compare
+        -- their captured gen to the live one and ignore themselves if
+        -- stale. Without this, an onError/onClosed from the just-closed
+        -- listener can flag rebind AGAIN immediately after we just
+        -- finished rebinding, looping us out of the new client.
+        pluginState.responseGen = 0
+
+        local function bindResponse()
+            pluginState.responseGen = pluginState.responseGen + 1
+            local myGen = pluginState.responseGen
+            local function isLive() return pluginState.responseGen == myGen end
+            return LrSocket.bind {
+                functionContext = context,
+                plugin = _PLUGIN,
+                port = responsePort,
+                mode = "send",
+                onConnected = function()
+                    if not isLive() then return end
+                    pluginState.sendConnected = true
+                    addLog("RESPONSE socket connected")
+                end,
+                onClosed = function()
+                    if not isLive() then return end
+                    pluginState.sendConnected = false
+                    pluginState.responseNeedsRebind = true
+                end,
+                onError = function(_, err)
+                    if not isLive() then return end
+                    local errStr = tostring(err)
+                    if isNoClientError(errStr) then
+                        if not pluginState.sendConnected then
+                            pluginState.responseNeedsReconnect = true
+                        end
+                    else
+                        pluginState.sendConnected = false
+                        pluginState.responseNeedsRebind = true
+                        addLog("RESPONSE socket error: " .. errStr)
+                    end
+                end,
+            }
+        end
+
+        pluginState.requestSocket = bindRequest()
+        addLog("REQUEST bound on " .. requestPort)
+        pluginState.responseSocket = bindResponse()
         addLog("RESPONSE bound on " .. responsePort)
 
         while pluginState.running do
@@ -278,7 +328,18 @@ local function startServer()
                 pluginState.requestNeedsReconnect = false
                 pluginState.requestSocket:reconnect()
             end
-            if pluginState.responseNeedsReconnect and pluginState.responseSocket then
+            -- Response socket has two recovery paths:
+            -- - rebind: full close+rebind for true client disconnect
+            -- - reconnect: cheap reconnect for listen-side timeouts
+            if pluginState.responseNeedsRebind then
+                if pluginState.responseSocket then
+                    pcall(function() pluginState.responseSocket:close() end)
+                end
+                pluginState.responseSocket = bindResponse()
+                pluginState.responseNeedsRebind = false
+                pluginState.responseNeedsReconnect = false
+                addLog("RESPONSE rebound on " .. responsePort)
+            elseif pluginState.responseNeedsReconnect and pluginState.responseSocket then
                 pluginState.responseNeedsReconnect = false
                 pluginState.responseSocket:reconnect()
             end
@@ -296,7 +357,6 @@ local function startServer()
         pluginState.responseSocket = nil
         pluginState.sendConnected = false
         pluginState.receiveConnected = false
-        pluginState.authenticated = false
         pluginState.token = nil
     end)
 end
@@ -371,7 +431,7 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
             },
             f:row {
                 f:static_text { title = "Request port:", width = 110 },
-                f:edit_text {
+                f:edit_field {
                     value = LrView.bind('requestPort'),
                     width_in_chars = 7,
                     precision = 0,
@@ -382,7 +442,7 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
             },
             f:row {
                 f:static_text { title = "Response port:", width = 110 },
-                f:edit_text {
+                f:edit_field {
                     value = LrView.bind('responsePort'),
                     width_in_chars = 7,
                     precision = 0,

--- a/plugin/LightroomMCP.lrplugin/PluginShutdown.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginShutdown.lua
@@ -1,0 +1,12 @@
+-- Called when Lightroom is shutting down. Tear down sockets cleanly so
+-- ports are released before Lr exits.
+local state = _G.LightroomMCP_State
+if state then
+    state.running = false
+    if state.requestSocket then
+        pcall(function() state.requestSocket:close() end)
+    end
+    if state.responseSocket then
+        pcall(function() state.responseSocket:close() end)
+    end
+end

--- a/plugin/spec/PhotoLookup_spec.lua
+++ b/plugin/spec/PhotoLookup_spec.lua
@@ -9,18 +9,11 @@ local function fakePhoto(id, path)
 end
 
 local function fakeCatalog(photos)
-    local state = { getAllPhotosCalls = 0, findByIdCalls = 0 }
+    local state = { getAllPhotosCalls = 0 }
     local catalog = {
         getAllPhotos = function()
             state.getAllPhotosCalls = state.getAllPhotosCalls + 1
             return photos
-        end,
-        findPhotoByLocalIdentifier = function(_, id)
-            state.findByIdCalls = state.findByIdCalls + 1
-            for _, p in ipairs(photos) do
-                if p.localIdentifier == id then return p end
-            end
-            return nil
         end,
     }
     return catalog, state
@@ -35,7 +28,7 @@ end
 describe("PhotoLookup.resolveMany", function()
     before_each(loadModule)
 
-    it("resolves all-numeric ids without scanning the catalog", function()
+    it("resolves numeric localIdentifier ids in one catalog scan", function()
         local p1 = fakePhoto(1, "/a.jpg")
         local p2 = fakePhoto(2, "/b.jpg")
         local catalog, state = fakeCatalog({ p1, p2 })
@@ -44,11 +37,10 @@ describe("PhotoLookup.resolveMany", function()
 
         assert.are.equal(p1, r[1].photo)
         assert.are.equal(p2, r[2].photo)
-        assert.are.equal(0, state.getAllPhotosCalls)
-        assert.are.equal(2, state.findByIdCalls)
+        assert.are.equal(1, state.getAllPhotosCalls)
     end)
 
-    it("falls back to path lookup with exactly one scan", function()
+    it("resolves by path", function()
         local p1 = fakePhoto(1, "/a.jpg")
         local p2 = fakePhoto(2, "/b.jpg")
         local catalog, state = fakeCatalog({ p1, p2 })
@@ -60,7 +52,7 @@ describe("PhotoLookup.resolveMany", function()
         assert.are.equal(1, state.getAllPhotosCalls)
     end)
 
-    it("does one scan for a mixed batch (some by id, some by path)", function()
+    it("resolves a mixed batch (some by id, some by path)", function()
         local p1 = fakePhoto(1, "/a.jpg")
         local p2 = fakePhoto(2, "/b.jpg")
         local p3 = fakePhoto(3, "/c.jpg")
@@ -76,15 +68,13 @@ describe("PhotoLookup.resolveMany", function()
 
     it("returns nil for unknown ids without erroring", function()
         local p1 = fakePhoto(1, "/a.jpg")
-        local catalog, state = fakeCatalog({ p1 })
+        local catalog, _ = fakeCatalog({ p1 })
 
         local r = PhotoLookup.resolveMany(catalog, { "1", "999", "/missing.jpg" })
 
         assert.are.equal(p1, r[1].photo)
         assert.is_nil(r[2].photo)
         assert.is_nil(r[3].photo)
-        -- One scan triggered by the misses; not three.
-        assert.are.equal(1, state.getAllPhotosCalls)
     end)
 
     it("preserves input order in results", function()
@@ -101,10 +91,9 @@ describe("PhotoLookup.resolveMany", function()
     end)
 
     it("handles empty input", function()
-        local catalog, state = fakeCatalog({})
+        local catalog, _ = fakeCatalog({})
         local r = PhotoLookup.resolveMany(catalog, {})
         assert.are.equal(0, #r)
-        assert.are.equal(0, state.getAllPhotosCalls)
     end)
 end)
 

--- a/server/src/dispatcher.ts
+++ b/server/src/dispatcher.ts
@@ -12,6 +12,7 @@ interface PendingResponse {
 
 export interface DispatcherOptions {
   send: (line: string) => boolean;
+  getToken: () => string;
   timeoutMs?: number;
   log?: (msg: string) => void;
 }
@@ -21,10 +22,12 @@ export class Dispatcher {
   private idCounter = 0;
   private readonly timeoutMs: number;
   private readonly send: (line: string) => boolean;
+  private readonly getToken: () => string;
   private readonly log: (msg: string) => void;
 
   constructor(opts: DispatcherOptions) {
     this.send = opts.send;
+    this.getToken = opts.getToken;
     this.timeoutMs = opts.timeoutMs ?? 30_000;
     this.log = opts.log ?? ((msg: string) => console.error(msg));
   }
@@ -58,11 +61,22 @@ export class Dispatcher {
       this.pending.set(id, { resolve, reject, timer });
     });
 
-    const sent = this.send(JSON.stringify({ id, action, params: params ?? {} }));
-    if (!sent) {
+    const cleanup = () => {
       const p = this.pending.get(id);
       if (p) clearTimeout(p.timer);
       this.pending.delete(id);
+    };
+
+    let payload: string;
+    try {
+      payload = JSON.stringify({ hello: this.getToken(), id, action, params: params ?? {} });
+    } catch (err) {
+      cleanup();
+      throw err;
+    }
+
+    if (!this.send(payload)) {
+      cleanup();
       throw new Error("Failed to send request to plugin (socket dropped)");
     }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,17 +28,12 @@ try {
 const requestSocket = new PluginSocket({
   port: REQUEST_PORT,
   label: "request",
-  onConnect: () => {
-    try {
-      const token = readToken();
-      requestSocket.send(JSON.stringify({ hello: token }));
-    } catch (err) {
-      console.error(`[request] token read failed: ${(err as Error).message}`);
-    }
-  },
 });
 const dispatcher = new Dispatcher({
   send: (line) => requestSocket.send(line),
+  // Re-read on every call so a token rotation by the plugin (e.g. server
+  // restart in Plug-in Manager) is picked up without bouncing this process.
+  getToken: () => readToken(),
   timeoutMs: REQUEST_TIMEOUT_MS,
 });
 const responseSocket = new PluginSocket({

--- a/server/tests/dispatcher.test.ts
+++ b/server/tests/dispatcher.test.ts
@@ -17,6 +17,7 @@ describe('Dispatcher', () => {
         sent.push(line);
         return true;
       },
+      getToken: () => 'test-token',
       timeoutMs: 1000,
       log: (msg) => logs.push(msg),
     });

--- a/tests/e2e/PLAN.md
+++ b/tests/e2e/PLAN.md
@@ -1,0 +1,371 @@
+# Lightroom MCP — manual e2e playbook
+
+End-to-end manual test plan. Designed to be **run in order**: each phase
+builds on the prior. Stop at the first failing phase, fix, restart.
+
+Two helpers do most of the work:
+
+- `tests/e2e/mcp-runner.mjs` — spawns the built MCP server and drives it
+  over stdio (same protocol Claude Desktop uses). Scripted, repeatable.
+- `manual-test.mjs` — raw TCP probe straight at plugin sockets, bypasses
+  MCP. Useful for isolating "is it the server or the plugin?".
+
+Both honour `LIGHTROOM_MCP_REQUEST_PORT` / `LIGHTROOM_MCP_RESPONSE_PORT`
+/ `LIGHTROOM_MCP_TOKEN_PATH`.
+
+---
+
+## Phase 0 — pre-flight (one-time setup)
+
+Goal: plugin installed, server built, all artefacts present.
+
+**Steps**
+
+1. Copy plugin into Lightroom plugins dir
+   ```sh
+   cp -R plugin/LightroomMCP.lrplugin "$HOME/Library/Application Support/Adobe/Lightroom/Plugins/"
+   ```
+2. Open Lightroom Classic → **File → Plug-in Manager → Lightroom MCP**
+3. Auto-start should be on. If not, click **Start Server**
+4. Build server
+   ```sh
+   mise run install && mise run build
+   ```
+
+**Pass criteria** — all of:
+
+```sh
+ls -la "$HOME/.config/lightroom-mcp/token"                   # exists, non-empty
+ls -la "$HOME/Documents/LrClassicLogs/LightroomMCP.log"      # exists
+lsof -nP -iTCP:58763 -iTCP:58764 | grep -i adobe             # both bound by Lightroom
+ls server/dist/index.js                                       # built
+```
+
+If anything's missing → see Phase 9 troubleshooting.
+
+---
+
+## Phase 1 — connectivity smoke
+
+Goal: server connects, token handshake succeeds, single round trip works.
+
+**Steps**
+
+```sh
+node manual-test.mjs list_collections
+```
+
+**Pass criteria**
+
+- `[request] connected :58763` and `[response] connected :58764` printed
+- `<<< { "id": "manual_…", "result": { "count": …, "collections": […] } }`
+- No `error` key in response
+- Lightroom Plug-in Manager → **Show Status** shows `Request socket connected: true`, `Response socket connected: true`, `Requests processed >= 1`
+
+**Failure modes & meaning**
+
+| symptom | cause |
+| --- | --- |
+| `ECONNREFUSED` on either port | plugin not started, or stale sockets after Reload Plug-in. Quit Lightroom (Cmd+Q), reopen |
+| `token read failed` | plugin never wrote token — Start Server hasn't been clicked |
+| handshake-then-immediate-disconnect | token mismatch; delete `~/.config/lightroom-mcp/token`, restart server in plugin |
+| timeout waiting for response | handler stuck; check Show Status `Last event` and the log file |
+
+---
+
+## Phase 2 — read-only suite (scripted)
+
+Goal: every read tool returns well-formed data against the live catalog.
+
+```sh
+node tests/e2e/mcp-runner.mjs read
+```
+
+**What it covers**
+
+- `tools/list` returns 14 tools (matches `server/src/index.ts`)
+- `list_collections` — paginated, count + array shape
+- `get_selected_photos` — paginated, array shape (works whether something is selected or not; falls back to filmstrip)
+- `search_photos` no-filter — returns first N photos
+- `search_photos` with `rating: 5` — exercises the searchDesc builder
+- `get_photo_metadata` by `localIdentifier` AND by file path — both lookup paths
+- `list_develop_presets` — exercises preset folder iteration
+
+**Pass criteria** — all `OK`, summary line shows `0 failed`.
+
+**Manual check in Lightroom (visual)**
+
+- Plug-in Manager → Show Status → `Requests processed` increased by ~7
+
+---
+
+## Phase 3 — selection-aware behaviour
+
+Goal: `get_selected_photos` actually reflects the filmstrip selection.
+
+**Steps**
+
+1. In Lightroom, navigate to a folder, **select 3 photos** in the filmstrip (Shift-click or Cmd-click)
+2. Run:
+   ```sh
+   node tests/e2e/mcp-runner.mjs tool get_selected_photos '{"limit":10}'
+   ```
+
+**Pass criteria**
+
+- `count: 3`, `photos: [...]` array length 3
+- The `filename` and `path` fields match what's selected
+
+**Edge: deselect everything** — repeat. `getTargetPhotos()` falls back to the entire filmstrip / folder; expect `count` to equal the visible photo count, not 0.
+
+---
+
+## Phase 4 — write suite (mutating, scripted)
+
+Goal: collections, ratings, keywords roundtrip via the catalog.
+
+⚠️ This phase **mutates** your catalog. It creates a uniquely-named
+collection (`MCP_E2E_<timestamp>`) and bumps rating/keywords on the first
+photo returned by `search_photos` (then restores). Use a non-production
+catalog if you'd rather not.
+
+```sh
+node tests/e2e/mcp-runner.mjs write
+```
+
+**What it covers**
+
+- `create_collection` with timestamped name
+- `list_collections` finds the new collection
+- `add_to_collection` adds first photo, asserts `added: 1`
+- `set_rating` 3 then restore to original
+- `get_photo_metadata` confirms rating roundtrip
+- `set_keywords` add `mcp_e2e_<ts>`, confirm via metadata, then remove, confirm gone
+
+**Manual check in Lightroom (visual)**
+
+- Library → Collections panel → new `MCP_E2E_…` collection visible, contains 1 photo
+- Open that photo → Keywording panel briefly showed `mcp_e2e_*` (then removed)
+
+**Cleanup**
+
+- Right-click `MCP_E2E_…` collection → Delete (the script doesn't auto-delete it; intentional, so you can inspect first)
+
+---
+
+## Phase 5 — develop suite (scripted)
+
+Goal: develop settings can be read, written directly, and applied via preset.
+
+⚠️ Mutates the first photo's exposure (sets to +0.5 EV, then restores to 0).
+
+```sh
+node tests/e2e/mcp-runner.mjs develop
+```
+
+**What it covers**
+
+- `set_develop_settings` with `Exposure2012: 0.5`, then read back via `get_photo_metadata.developSettings.exposure`, expect ~0.5
+- Restore to 0
+- `apply_develop_preset` using the first preset returned by `list_develop_presets`
+
+**Manual check**
+
+- Develop module on the test photo → Exposure briefly shows +0.50, then 0.00
+- After preset applied, History panel shows the preset name
+
+---
+
+## Phase 6 — copy_develop_settings (semi-manual)
+
+Not yet covered by the runner because it needs two distinct photo IDs.
+
+**Steps**
+
+1. Get two photo IDs:
+   ```sh
+   node tests/e2e/mcp-runner.mjs tool search_photos '{"limit":2}'
+   ```
+   note `photos[0].id` and `photos[1].id`.
+2. Apply a tweak to photo 0:
+   ```sh
+   node tests/e2e/mcp-runner.mjs tool set_develop_settings \
+     '{"photo_id":"<id0>","settings":{"Contrast2012":40,"Saturation":20}}'
+   ```
+3. Copy from 0 → 1:
+   ```sh
+   node tests/e2e/mcp-runner.mjs tool copy_develop_settings \
+     '{"source_id":"<id0>","target_ids":["<id1>"]}'
+   ```
+4. Verify on photo 1:
+   ```sh
+   node tests/e2e/mcp-runner.mjs tool get_photo_metadata '{"photo_id":"<id1>"}'
+   ```
+   Expect `developSettings.contrast == 40`, `developSettings.saturation == 20`.
+
+**Whitelist variant**
+
+Repeat step 3 with `"settings":["Contrast2012"]` and verify only contrast (not saturation) was copied.
+
+---
+
+## Phase 7 — import / export (semi-manual, slowest)
+
+Goal: catalog ingest + render pipeline.
+
+### 7a Import
+
+**Setup**
+
+```sh
+mkdir -p /tmp/lr_import_e2e
+# drop 2-3 sample JPEGs in there (any photo files you don't mind importing)
+```
+
+**Run**
+
+```sh
+node tests/e2e/mcp-runner.mjs tool import_photos \
+  '{"source_path":"/tmp/lr_import_e2e"}'
+```
+
+**Pass criteria**
+
+- response `{ "success": true, "imported": <n> }` with n matching files in folder
+- Library → Previous Import shows the new photos
+
+**Cleanup** — right-click in Library → Remove from Catalog.
+
+### 7b Export
+
+**Run**
+
+```sh
+mkdir -p /tmp/lr_export_e2e
+# pick a real photo id first:
+node tests/e2e/mcp-runner.mjs tool search_photos '{"limit":1}'
+# then export it as JPEG @1024px
+node tests/e2e/mcp-runner.mjs tool export_photos \
+  '{"photo_ids":["<id>"],"destination":"/tmp/lr_export_e2e","format":"jpeg","quality":85,"width":1024,"height":1024}'
+```
+
+**Pass criteria**
+
+- response `{ "success": true, "exported": 1 }`
+- `ls /tmp/lr_export_e2e` shows the JPEG
+- `sips -g pixelWidth -g pixelHeight /tmp/lr_export_e2e/*.jpg` shows long edge ≤ 1024
+
+**Format matrix** — repeat with `"png"`, `"tiff"`, `"original"`. Each should produce the corresponding file extension; for `original` the input format is preserved.
+
+---
+
+## Phase 8 — failure & edge cases (scripted)
+
+Goal: bad input is rejected with `isError: true`, not silent success or hang.
+
+```sh
+node tests/e2e/mcp-runner.mjs failure
+```
+
+**Covers**
+
+- unknown tool name → `isError: true`, "Unknown action: …"
+- `get_photo_metadata` with bogus id → `isError: true`, "Photo not found"
+- `set_rating` with rating=9 → `isError: true`, validation message
+- `create_collection` with no name → `isError: true`
+
+**Additional edges to probe by hand**
+
+| case | how | expected |
+| --- | --- | --- |
+| empty `photo_ids` array | `set_rating '{"photo_ids":[],"rating":3}'` | error "photo_ids is required" |
+| `add_to_collection` with non-existent collection | use a junk name | error "Collection not found" |
+| `import_photos` source_path doesn't exist | `'{"source_path":"/nope"}'` | error "Source path does not exist" |
+| `export_photos` destination not writable | `'{"photo_ids":["<id>"],"destination":"/etc/lr_e2e_denied"}'` | error from LrExportSession |
+
+---
+
+## Phase 9 — resilience: reload, restart, port mismatch
+
+These probe the auto-reconnect + token + port-config code paths.
+
+### 9a Plugin reload (sockets stay bound)
+
+1. With server running, hit **Reload Plug-in** in Plug-in Manager
+2. Run `node tests/e2e/mcp-runner.mjs read` again — should still work (token regenerates, server reconnects, picks up new token from disk)
+3. **Known limitation** (CLAUDE.md): if Reload leaves the prior async task wedged, you'll see `failed to open localhost:58763`. Fix is Cmd+Q + reopen, not Reload again.
+
+### 9b Server restart
+
+1. Mid-suite, kill the harness process (Ctrl-C)
+2. Re-run — plugin should still be bound, new server reconnects within ~1s
+3. Plug-in Manager → Show Status → `Request socket connected: true` resumes
+
+### 9c Wrong token
+
+1. Backup token: `cp ~/.config/lightroom-mcp/token /tmp/tok_real`
+2. Corrupt: `printf 'wrong' > ~/.config/lightroom-mcp/token`
+3. Run `node tests/e2e/mcp-runner.mjs tool list_collections '{}'`
+4. Expect: server connects, plugin drops connection, server logs reconnect storm; tool call times out
+5. Restore: `cp /tmp/tok_real ~/.config/lightroom-mcp/token` and verify recovery
+
+### 9d Port mismatch
+
+1. Set `LIGHTROOM_MCP_REQUEST_PORT=58773 LIGHTROOM_MCP_RESPONSE_PORT=58774` in shell
+2. Run `node tests/e2e/mcp-runner.mjs tool list_collections '{}'`
+3. Expect: server prints connect failures; tool returns `Lightroom plugin not connected.`
+4. Open Plug-in Manager, edit ports to 58773/58774, Stop + Start server
+5. Re-run: succeeds. Restore defaults afterwards.
+
+---
+
+## Phase 10 — concurrency / pagination
+
+Goal: Dispatcher correctly demuxes responses by id; pagination is consistent.
+
+### 10a Pagination consistency
+
+```sh
+node tests/e2e/mcp-runner.mjs tool search_photos '{"limit":3,"offset":0}'
+node tests/e2e/mcp-runner.mjs tool search_photos '{"limit":3,"offset":3}'
+```
+
+Photos in the second call must not appear in the first (no overlap). `count` should be identical across both calls. `has_more` true on the first if catalog > 3.
+
+### 10b Parallel calls (advanced, optional)
+
+In one terminal, run two tool calls "at once" by piping the runner with shell `&`:
+
+```sh
+node tests/e2e/mcp-runner.mjs tool search_photos '{"limit":1,"offset":0}' &
+node tests/e2e/mcp-runner.mjs tool list_collections '{}' &
+wait
+```
+
+Each spawns its own server (so this is two parallel sessions, not multiplexed in one connection — the plugin only allows one client per port). Both should succeed.
+
+**True multiplexing** (multiple in-flight requests on one connection) — not exercised by the harness today; would require extending it to fire several `callTool` promises before awaiting. If you want, the dispatcher already supports it (`pendingCount()` is exposed), so add a scenario that does `Promise.all([c.callTool(...), c.callTool(...)])` and assert both resolve.
+
+---
+
+## Quick reference
+
+```sh
+# happy path, all phases that are auto-runnable
+node tests/e2e/mcp-runner.mjs all
+
+# one-shot single tool
+node tests/e2e/mcp-runner.mjs tool <name> '<json>'
+
+# inspect server's tool catalog
+node tests/e2e/mcp-runner.mjs list-tools
+
+# raw TCP probe (skips MCP entirely)
+node manual-test.mjs <action> '<json>'
+```
+
+## Unresolved
+
+- harness doesn't auto-cleanup the test collection — intentional, but if you run write phase a lot you'll accumulate `MCP_E2E_*` collections; consider a `--cleanup` flag
+- import/export phases need user-supplied test files and aren't part of `all`
+- no concurrency assertion in scripted runner; add `Promise.all` scenario when needed

--- a/tests/e2e/mcp-runner.mjs
+++ b/tests/e2e/mcp-runner.mjs
@@ -1,0 +1,616 @@
+#!/usr/bin/env node
+// E2E harness — drives the built MCP server over stdio (same protocol Claude Desktop uses)
+// and runs scripted scenarios against the real Lightroom plugin.
+//
+// Prereqs:
+//   1. Lightroom open, plugin "Start Server" clicked (token file exists, sockets bound)
+//   2. server built: `mise run build`
+//
+// Usage:
+//   node tests/e2e/mcp-runner.mjs                 # full read-only suite
+//   node tests/e2e/mcp-runner.mjs read            # read-only ops
+//   node tests/e2e/mcp-runner.mjs write           # mutating ops (creates collection, sets rating, etc.)
+//   node tests/e2e/mcp-runner.mjs develop         # develop module ops
+//   node tests/e2e/mcp-runner.mjs failure         # error/edge-case ops
+//   node tests/e2e/mcp-runner.mjs all             # everything except import/export
+//   node tests/e2e/mcp-runner.mjs tool <name> '<json>'   # one-shot single tool call
+//   node tests/e2e/mcp-runner.mjs list-tools      # dump tool catalog from server
+//
+// Exit code is non-zero if any scenario fails.
+
+import { spawn, execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import { once } from "node:events";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SERVER_BIN = path.join(REPO_ROOT, "server", "dist", "index.js");
+
+const args = process.argv.slice(2);
+const mode = args[0] ?? "read";
+
+class McpClient {
+  constructor() {
+    this.proc = null;
+    this.buf = "";
+    this.nextId = 1;
+    this.pending = new Map();
+    this.stderrTail = [];
+  }
+
+  async start() {
+    this.proc = spawn("node", [SERVER_BIN], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env },
+    });
+    this.proc.stdout.setEncoding("utf8");
+    this.proc.stderr.setEncoding("utf8");
+    this.proc.stdout.on("data", (chunk) => this._onStdout(chunk));
+    this.proc.stderr.on("data", (chunk) => {
+      const lines = chunk.split("\n").filter(Boolean);
+      this.stderrTail.push(...lines);
+      while (this.stderrTail.length > 50) this.stderrTail.shift();
+    });
+    this.proc.on("exit", (code) => {
+      for (const { reject } of this.pending.values()) {
+        reject(new Error(`server exited code=${code}\nstderr tail:\n${this.stderrTail.join("\n")}`));
+      }
+      this.pending.clear();
+    });
+
+    // initialize
+    await this._rpc("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "lightroom-mcp-e2e", version: "0.0.0" },
+    });
+    this._notify("notifications/initialized", {});
+    // Wait until a real plugin call succeeds. Plugin's response socket
+    // can take a few seconds to accept after a rebind cycle; isReady()
+    // alone isn't enough. We poll a cheap call until it returns.
+    const deadline = Date.now() + 20_000;
+    while (Date.now() < deadline) {
+      try {
+        const r = await this._rpc(
+          "tools/call",
+          { name: "list_collections", arguments: { limit: 1 } },
+          5_000,
+        );
+        const text = r?.content?.[0]?.text ?? "";
+        if (!r.isError && !text.includes("not connected")) return;
+      } catch {}
+      await sleep(500);
+    }
+    throw new Error("plugin did not become ready within 20s");
+  }
+
+  _onStdout(chunk) {
+    this.buf += chunk;
+    let idx;
+    while ((idx = this.buf.indexOf("\n")) !== -1) {
+      const line = this.buf.slice(0, idx).trim();
+      this.buf = this.buf.slice(idx + 1);
+      if (!line) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id != null && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+        else resolve(msg.result);
+      }
+    }
+  }
+
+  _send(obj) {
+    this.proc.stdin.write(JSON.stringify(obj) + "\n");
+  }
+
+  _notify(method, params) {
+    this._send({ jsonrpc: "2.0", method, params });
+  }
+
+  _rpc(method, params, timeoutMs = 35_000) {
+    const id = this.nextId++;
+    const p = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`rpc timeout: ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+    });
+    this._send({ jsonrpc: "2.0", id, method, params });
+    return p;
+  }
+
+  listTools() {
+    return this._rpc("tools/list", {});
+  }
+
+  async callTool(name, toolArgs) {
+    const result = await this._rpc("tools/call", { name, arguments: toolArgs ?? {} });
+    const text = result?.content?.[0]?.text ?? "";
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    return { isError: !!result.isError, text, parsed };
+  }
+
+  async stop() {
+    if (!this.proc) return;
+    this.proc.stdin.end();
+    try {
+      await Promise.race([once(this.proc, "exit"), sleep(2000)]);
+    } catch {}
+    if (this.proc.exitCode === null) this.proc.kill("SIGKILL");
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+
+function checkEq(label, got, want) {
+  if (got !== want) throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+function checkTrue(label, cond, ctx) {
+  if (!cond) throw new Error(`${label}: ${ctx ?? "expected truthy"}`);
+}
+
+async function run(label, fn) {
+  process.stdout.write(`▶ ${label} ... `);
+  try {
+    const out = await fn();
+    pass++;
+    console.log("OK", out ? `— ${out}` : "");
+  } catch (err) {
+    fail++;
+    failures.push({ label, err });
+    console.log("FAIL");
+    console.log(`   ${err.message.split("\n").slice(0, 4).join("\n   ")}`);
+  }
+}
+
+async function main() {
+  if (mode === "wrong-token") {
+    // Phase 9c — point the server at a token file that doesn't match
+    // what the plugin has. Real token file stays untouched, so a crash
+    // can't leave the system in a broken state (TOCTOU-safe).
+    const fakePath = path.join(os.tmpdir(), `lr_mcp_bad_token_${Date.now()}`);
+    fs.writeFileSync(fakePath, "wrong-token-deadbeef");
+    process.env.LIGHTROOM_MCP_TOKEN_PATH = fakePath;
+    let saw = false;
+    try {
+      const c = new McpClient();
+      try {
+        await c.start();
+      } catch (err) {
+        if (err.message.includes("did not become ready")) saw = true;
+        else console.log(`unexpected err: ${err.message}`);
+      }
+      await c.stop();
+    } finally {
+      delete process.env.LIGHTROOM_MCP_TOKEN_PATH;
+      fs.rmSync(fakePath, { force: true });
+    }
+    if (saw) console.log("wrong-token: plugin correctly rejected (ready-wait timed out)");
+    else console.log("wrong-token: UNEXPECTED — plugin accepted bad token!");
+    process.exitCode = saw ? 0 : 1;
+    return;
+  }
+
+  if (mode === "port-mismatch") {
+    // Phase 9d — server uses port 58773 (no plugin there), expect "not connected"
+    const c = new McpClient();
+    process.env.LIGHTROOM_MCP_REQUEST_PORT = "58773";
+    process.env.LIGHTROOM_MCP_RESPONSE_PORT = "58774";
+    let saw = false;
+    try {
+      await c.start();
+    } catch (err) {
+      if (err.message.includes("did not become ready")) saw = true;
+    }
+    delete process.env.LIGHTROOM_MCP_REQUEST_PORT;
+    delete process.env.LIGHTROOM_MCP_RESPONSE_PORT;
+    await c.stop();
+    if (saw) console.log("port-mismatch: server correctly failed to connect to wrong ports");
+    else console.log("port-mismatch: UNEXPECTED — server reached plugin");
+    process.exitCode = saw ? 0 : 1;
+    return;
+  }
+
+  if (mode === "list-tools") {
+    const c = new McpClient();
+    await c.start();
+    const tools = await c.listTools();
+    console.log(JSON.stringify(tools, null, 2));
+    await c.stop();
+    return;
+  }
+
+  if (mode === "tool") {
+    const toolName = args[1];
+    const toolArgs = args[2] ? JSON.parse(args[2]) : {};
+    if (!toolName) {
+      console.error("usage: mcp-runner.mjs tool <name> '<json>'");
+      process.exit(2);
+    }
+    const c = new McpClient();
+    await c.start();
+    const out = await c.callTool(toolName, toolArgs);
+    console.log(JSON.stringify(out.parsed ?? out.text, null, 2));
+    if (out.isError) process.exitCode = 1;
+    await c.stop();
+    return;
+  }
+
+  const c = new McpClient();
+  await c.start();
+
+  const ctx = {};
+
+  if (mode === "read" || mode === "all") {
+    await run("tools/list returns 14 tools", async () => {
+      const tools = await c.listTools();
+      checkEq("tool count", tools.tools.length, 14);
+    });
+
+    await run("list_collections smoke", async () => {
+      const r = await c.callTool("list_collections", { limit: 5 });
+      checkTrue("not error", !r.isError, r.text);
+      checkTrue("count is number", typeof r.parsed.count === "number");
+      return `count=${r.parsed.count}, returned=${r.parsed.collections.length}`;
+    });
+
+    await run("get_selected_photos returns shape", async () => {
+      const r = await c.callTool("get_selected_photos", { limit: 5 });
+      checkTrue("not error", !r.isError, r.text);
+      checkTrue("photos array", Array.isArray(r.parsed.photos));
+      ctx.firstSelected = r.parsed.photos[0];
+      return `count=${r.parsed.count}`;
+    });
+
+    await run("search_photos no filters paginates", async () => {
+      const r = await c.callTool("search_photos", { limit: 3 });
+      checkTrue("not error", !r.isError, r.text);
+      checkTrue("photos array", Array.isArray(r.parsed.photos));
+      ctx.firstPhoto = r.parsed.photos[0];
+      return `count=${r.parsed.count}, returned=${r.parsed.photos.length}`;
+    });
+
+    await run("search_photos rating=5 (may be 0)", async () => {
+      const r = await c.callTool("search_photos", { rating: 5, limit: 3 });
+      checkTrue("not error", !r.isError, r.text);
+      return `count=${r.parsed.count}`;
+    });
+
+    await run("get_photo_metadata for first photo", async () => {
+      if (!ctx.firstPhoto) throw new Error("no photo to test against");
+      const r = await c.callTool("get_photo_metadata", {
+        photo_id: String(ctx.firstPhoto.id),
+      });
+      checkTrue("not error", !r.isError, r.text);
+      checkTrue("has filename", typeof r.parsed.filename === "string");
+      checkTrue("has developSettings", typeof r.parsed.developSettings === "object");
+      return `${r.parsed.filename}`;
+    });
+
+    await run("get_photo_metadata by file path", async () => {
+      if (!ctx.firstPhoto) throw new Error("no photo to test against");
+      const r = await c.callTool("get_photo_metadata", { photo_id: ctx.firstPhoto.path });
+      checkTrue("not error", !r.isError, r.text);
+      checkEq("path roundtrip", r.parsed.path, ctx.firstPhoto.path);
+    });
+
+    await run("list_develop_presets", async () => {
+      const r = await c.callTool("list_develop_presets", {});
+      checkTrue("not error", !r.isError, r.text);
+      checkTrue("count is number", typeof r.parsed.count === "number");
+      ctx.firstPreset = r.parsed.presets[0];
+      return `count=${r.parsed.count}`;
+    });
+  }
+
+  if (mode === "write" || mode === "all") {
+    const collectionName = `MCP_E2E_${Date.now()}`;
+    ctx.collectionName = collectionName;
+
+    await run(`create_collection "${collectionName}"`, async () => {
+      const r = await c.callTool("create_collection", { name: collectionName });
+      checkTrue("not error", !r.isError, r.text);
+      checkEq("success", r.parsed.success, true);
+    });
+
+    await run("list_collections includes new collection", async () => {
+      const r = await c.callTool("list_collections", { limit: 1000 });
+      checkTrue("not error", !r.isError, r.text);
+      const found = r.parsed.collections.find((c) => c.name === collectionName);
+      checkTrue("found", !!found, `${collectionName} not in list`);
+    });
+
+    if (!ctx.firstPhoto) {
+      const search = await c.callTool("search_photos", { limit: 1 });
+      ctx.firstPhoto = search.parsed.photos?.[0];
+    }
+
+    if (ctx.firstPhoto) {
+      await run("add_to_collection (first photo)", async () => {
+        const r = await c.callTool("add_to_collection", {
+          collection_name: collectionName,
+          photo_ids: [String(ctx.firstPhoto.id)],
+        });
+        checkTrue("not error", !r.isError, r.text);
+        checkEq("added", r.parsed.added, 1);
+      });
+
+      const originalRating = ctx.firstPhoto.rating ?? 0;
+      await run("set_rating to 3", async () => {
+        const r = await c.callTool("set_rating", {
+          photo_ids: [String(ctx.firstPhoto.id)],
+          rating: 3,
+        });
+        checkTrue("not error", !r.isError, r.text);
+        checkEq("updated", r.parsed.updated, 1);
+      });
+
+      await run("get_photo_metadata reflects rating=3", async () => {
+        const r = await c.callTool("get_photo_metadata", {
+          photo_id: String(ctx.firstPhoto.id),
+        });
+        checkEq("rating", r.parsed.rating, 3);
+      });
+
+      await run(`set_rating restore to ${originalRating}`, async () => {
+        const r = await c.callTool("set_rating", {
+          photo_ids: [String(ctx.firstPhoto.id)],
+          rating: originalRating,
+        });
+        checkTrue("not error", !r.isError, r.text);
+      });
+
+      const tag = `mcp_e2e_${Date.now()}`;
+      await run(`set_keywords add "${tag}"`, async () => {
+        const r = await c.callTool("set_keywords", {
+          photo_ids: [String(ctx.firstPhoto.id)],
+          add_keywords: [tag],
+        });
+        checkTrue("not error", !r.isError, r.text);
+        checkEq("updated", r.parsed.updated, 1);
+      });
+
+      await run("get_photo_metadata shows new keyword", async () => {
+        const r = await c.callTool("get_photo_metadata", {
+          photo_id: String(ctx.firstPhoto.id),
+        });
+        checkTrue("keyword present", r.parsed.keywords.includes(tag), JSON.stringify(r.parsed.keywords));
+      });
+
+      await run(`set_keywords remove "${tag}"`, async () => {
+        const r = await c.callTool("set_keywords", {
+          photo_ids: [String(ctx.firstPhoto.id)],
+          remove_keywords: [tag],
+        });
+        checkTrue("not error", !r.isError, r.text);
+      });
+
+      await run("get_photo_metadata no longer shows keyword", async () => {
+        const r = await c.callTool("get_photo_metadata", {
+          photo_id: String(ctx.firstPhoto.id),
+        });
+        // Lua's JSON serializes an empty {} as object, not array. Treat
+        // both as "no keywords match the tag we just removed".
+        const kws = Array.isArray(r.parsed.keywords) ? r.parsed.keywords : [];
+        checkTrue("keyword gone", !kws.includes(tag), JSON.stringify(r.parsed.keywords));
+      });
+    } else {
+      console.log("⚠ skipping photo-mutation tests — catalog appears empty");
+    }
+  }
+
+  if (mode === "develop" || mode === "all") {
+    if (!ctx.firstPhoto) {
+      const search = await c.callTool("search_photos", { limit: 1 });
+      ctx.firstPhoto = search.parsed.photos?.[0];
+    }
+    if (!ctx.firstPreset) {
+      const list = await c.callTool("list_develop_presets", {});
+      ctx.firstPreset = list.parsed.presets?.[0];
+    }
+
+    if (ctx.firstPhoto) {
+      await run("set_develop_settings Exposure2012=0.5 then 0.0", async () => {
+        const r1 = await c.callTool("set_develop_settings", {
+          photo_id: String(ctx.firstPhoto.id),
+          settings: { Exposure2012: 0.5 },
+        });
+        checkTrue("first not error", !r1.isError, r1.text);
+        const meta = await c.callTool("get_photo_metadata", {
+          photo_id: String(ctx.firstPhoto.id),
+        });
+        checkTrue("exposure ~0.5", Math.abs((meta.parsed.developSettings.exposure ?? 0) - 0.5) < 1e-6,
+          `got ${meta.parsed.developSettings.exposure}`);
+        const r2 = await c.callTool("set_develop_settings", {
+          photo_id: String(ctx.firstPhoto.id),
+          settings: { Exposure2012: 0.0 },
+        });
+        checkTrue("restore not error", !r2.isError, r2.text);
+      });
+
+      if (ctx.firstPreset) {
+        await run(`apply_develop_preset "${ctx.firstPreset.name}"`, async () => {
+          const r = await c.callTool("apply_develop_preset", {
+            photo_ids: [String(ctx.firstPhoto.id)],
+            preset_name: ctx.firstPreset.name,
+          });
+          checkTrue("not error", !r.isError, r.text);
+          checkEq("applied", r.parsed.applied, 1);
+        });
+      }
+    }
+  }
+
+  if (mode === "develop" || mode === "all") {
+    // copy_develop_settings (Phase 6) — needs two photos
+    const twoPhotos = await c.callTool("search_photos", { limit: 2 });
+    if (!twoPhotos.isError && twoPhotos.parsed.photos.length >= 2) {
+      const src = twoPhotos.parsed.photos[0];
+      const dst = twoPhotos.parsed.photos[1];
+
+      await run("copy_develop_settings (whitelist Contrast2012)", async () => {
+        await c.callTool("set_develop_settings", {
+          photo_id: String(src.id),
+          settings: { Contrast2012: 42 },
+        });
+        const cp = await c.callTool("copy_develop_settings", {
+          source_id: String(src.id),
+          target_ids: [String(dst.id)],
+          settings: ["Contrast2012"],
+        });
+        checkTrue("not error", !cp.isError, cp.text);
+        checkEq("copied", cp.parsed.copied, 1);
+        const dstMeta = await c.callTool("get_photo_metadata", {
+          photo_id: String(dst.id),
+        });
+        checkEq("dst contrast", dstMeta.parsed.developSettings.contrast, 42);
+        // restore source
+        await c.callTool("set_develop_settings", {
+          photo_id: String(src.id),
+          settings: { Contrast2012: 0 },
+        });
+        await c.callTool("set_develop_settings", {
+          photo_id: String(dst.id),
+          settings: { Contrast2012: 0 },
+        });
+      });
+    }
+  }
+
+  if (mode === "export" || mode === "all") {
+    // Phase 7b — export to /tmp, verify file + dimensions.
+    // Prefer a real photo (rating>=1 typically means actual catalog content,
+    // skipping test fixtures like synthetic PNGs that LR refuses to render).
+    let search = await c.callTool("search_photos", { rating: 5, limit: 1 });
+    if (search.isError || !search.parsed.photos?.length) {
+      search = await c.callTool("search_photos", { limit: 1 });
+    }
+    const photo = search.parsed.photos?.[0];
+    if (photo) {
+      const dest = path.join(os.tmpdir(), `lr_export_e2e_${Date.now()}`);
+      fs.mkdirSync(dest, { recursive: true });
+      await run(`export_photos JPEG @1024 → ${dest}`, async () => {
+        const r = await c.callTool("export_photos", {
+          photo_ids: [String(photo.id)],
+          destination: dest,
+          format: "jpeg",
+          quality: 80,
+          width: 1024,
+          height: 1024,
+        });
+        checkTrue("not error", !r.isError, r.text);
+        checkEq("exported count", r.parsed.exported, 1);
+        // Search recursively in case LR put it in a subfolder, AND search
+        // the photo's source folder (in case destinationType was ignored).
+        const allInDest = execFileSync("find", [dest, "-type", "f"], { encoding: "utf8" }).trim();
+        const jpegs = allInDest.split("\n").filter((p) => /\.(jpe?g)$/i.test(p));
+        checkTrue("at least one jpeg", jpegs.length >= 1,
+          `dest tree: [${allInDest}], srcDir: ${path.dirname(photo.path)}`);
+        const out = jpegs[0];
+        const sips = execFileSync("sips", ["-g", "pixelWidth", "-g", "pixelHeight", out], {
+          encoding: "utf8",
+        });
+        const w = Number((sips.match(/pixelWidth: (\d+)/) ?? [])[1]);
+        const h = Number((sips.match(/pixelHeight: (\d+)/) ?? [])[1]);
+        checkTrue("long edge ≤ 1024", Math.max(w, h) <= 1024, `got ${w}x${h}`);
+      });
+      // Keep dest around for inspection if test failed
+      if (failures.find((f) => f.label.startsWith("export_photos"))) {
+        console.log(`(left ${dest} for inspection)`);
+      } else {
+        fs.rmSync(dest, { recursive: true, force: true });
+      }
+    }
+  }
+
+  if (mode === "pagination" || mode === "all") {
+    // Phase 10a — offset/limit slices don't overlap, count is stable
+    await run("search_photos pagination is consistent", async () => {
+      const a = await c.callTool("search_photos", { limit: 5, offset: 0 });
+      const b = await c.callTool("search_photos", { limit: 5, offset: 5 });
+      checkEq("count stable", a.parsed.count, b.parsed.count);
+      const aIds = new Set(a.parsed.photos.map((p) => String(p.id)));
+      const bIds = b.parsed.photos.map((p) => String(p.id));
+      const overlap = bIds.filter((id) => aIds.has(id));
+      checkEq("no overlap", overlap.length, 0);
+      if (a.parsed.count > 5) checkEq("page 1 has_more", a.parsed.has_more, true);
+    });
+
+    // Concurrent in-flight calls — exercises dispatcher demux
+    await run("Promise.all of three different calls", async () => {
+      const [r1, r2, r3] = await Promise.all([
+        c.callTool("list_collections", { limit: 1 }),
+        c.callTool("search_photos", { limit: 1 }),
+        c.callTool("list_develop_presets", {}),
+      ]);
+      checkTrue("r1 ok", !r1.isError, r1.text);
+      checkTrue("r2 ok", !r2.isError, r2.text);
+      checkTrue("r3 ok", !r3.isError, r3.text);
+    });
+  }
+
+  if (mode === "failure" || mode === "all") {
+    await run("unknown tool returns isError", async () => {
+      const r = await c.callTool("does_not_exist", {});
+      checkEq("isError", r.isError, true);
+    });
+
+    await run("get_photo_metadata bad id returns isError", async () => {
+      const r = await c.callTool("get_photo_metadata", { photo_id: "not-a-real-id-99999" });
+      checkEq("isError", r.isError, true);
+    });
+
+    await run("set_rating out-of-range returns isError", async () => {
+      const r = await c.callTool("set_rating", { photo_ids: ["1"], rating: 9 });
+      checkEq("isError", r.isError, true);
+    });
+
+    await run("create_collection without name returns isError", async () => {
+      const r = await c.callTool("create_collection", {});
+      checkEq("isError", r.isError, true);
+    });
+  }
+
+  await c.stop();
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  if (fail > 0) {
+    console.log("\nfailures:");
+    for (const f of failures) console.log(`  - ${f.label}: ${f.err.message.split("\n")[0]}`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error("fatal:", err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Motivation

End-to-end testing of the LrSocket bridge against a real catalog surfaced ten production-blocking reliability bugs. Tools were timing out, plugin auto-start didn't fire, response sockets wedged after disconnect, and reload-detection sometimes ran two `pluginState` instances in parallel.

This PR makes the bridge actually work without manual nudges from the user, plus adds a scripted e2e harness so we can catch regressions before users do.

## Implementation information

**Auth — stateless per-message handshake.** Token now travels in `hello` on every request, plugin compares to `pluginState.token` on each message. The previous stateful flag desynced when async dispatch + reload-detection produced two `pluginState` tables racing for the accept queue.

**Lifecycle.**
- Plugin module init is idempotent — `_G.LightroomMCP_State` is only initialised if absent, so the two module loads (`PluginInit` require + `InfoProvider` load) share one state and one bind instead of racing.
- `LrForceInitPlugin = true` plus a Library menu entry triggers eager load at Lr launch (the flag is silently ignored without at least one menu item — verified pattern from Adobe's `remote_control_socket.lrdevplugin` sample).
- `LrShutdownPlugin` / `LrShutdownApp` tear down sockets cleanly.

**Sockets.**
- Send-mode `LrSocket:reconnect()` doesn't reliably re-fire `onConnected` after a client disconnect. Fix: hard `:close()` + new `LrSocket.bind` on `onClosed`, AND on every new request connection (new MCP session = new response peer).
- Generation counter (`responseGen`) on the response socket: callbacks captured by a closed listener early-return via `isLive()` so they can't flag a rebind after we've already rebound.
- `"failed to open localhost:..."` is the same benign no-client window as `"timeout"`; both are now matched by `isNoClientError`.

**Handlers.** Three real bugs unrelated to plumbing:
- `PhotoLookup`: catalog has no `findPhotoByLocalIdentifier`. Build id + path indexes from one `getAllPhotos()` pass.
- `set_rating(0)` passes `nil` to LR (literal 0 is rejected as invalid).
- `export_photos`: `LR_export_destinationType=specificFolder` so `LR_export_destinationPathPrefix` is honoured (was `sourceFolder`, ignoring the destination).

**Server.**
- Dispatcher `cleanup()` runs if `JSON.stringify` or `send` throws so a transient `getToken` failure doesn't leak the pending entry / timer.
- Token re-read per call so a plugin restart is picked up without bouncing the server.

**Plugin imports.** `LrUUID` / `LrPathUtils` / `LrFileUtils` were referenced but not imported (luacheck only validates names). `os.execute` isn't in the Lr Lua sandbox so the chmod best-effort hardening was dropped. `edit_field` is the right view-factory method (was `edit_text`, which doesn't exist).

**Test harness** (`tests/e2e/`).
- `mcp-runner.mjs` spawns the built server over stdio, runs scripted scenarios. Modes: `read / write / develop / export / pagination / failure / all`, plus standalone `wrong-token` / `port-mismatch` resilience.
- Waits until a real plugin call succeeds before starting (the 10s no-accept window + rebind cycles can take seconds to settle).
- `export_photos` test invokes `sips` to verify long-edge constraint.
- `wrong-token` points the server at a temp token via `LIGHTROOM_MCP_TOKEN_PATH` so the real token file is never touched (TOCTOU-safe).
- `tests/e2e/PLAN.md` is the playbook including phases that genuinely need UI interaction (filmstrip selection, Reload Plug-in).

## Supporting documentation

Verified **28/28 functional + 2/2 resilience** against a 5985-photo catalog with 78 collections and 393 develop presets. 38 unit tests still pass.

> Changelog: fix(plugin): harden dual-port bridge plumbing