### PR TITLE
perf(plugin): use findPhotos for filtered search

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Frame: line-delimited JSON, `\n` terminator on every message.
 - Auto-reconnect on disconnect (server side) and `:reconnect()` on socket timeout (plugin side)
 
 🚧 **Known issues**:
-- `search_photos` iterates `getAllPhotos()` — slow on large catalogs (~30s for several thousand photos). Needs catalog filter optimization.
 - "Reload Plug-in" doesn't kill the prior async task; sockets stay bound. Workaround: Quit Lightroom (Cmd+Q) and reopen.
 
 ## Prerequisites
@@ -254,7 +253,7 @@ Check Claude Desktop logs:
 Common issues:
 - **`failed to open localhost:58763` (or your configured port) after Reload Plug-in** — old async task still owns the port; Quit Lightroom (Cmd+Q) and reopen.
 - **MCP server reports "plugin not connected"** — click **Start Server** in Plug-in Manager; server reconnects automatically within 1s.
-- **Timeout errors** — handler may be stuck on a slow `getAllPhotos()` scan; check Show Status for `Last event` timestamp.
+- **Timeout errors** — handler may be scanning a large catalog without filters; add `rating`, `filename`, `keywords`, or date filters to narrow the search. Check Show Status for `Last event` timestamp.
 
 ## Troubleshooting
 
@@ -311,7 +310,7 @@ lightroom-mcp/
 ### Available Tools
 
 #### `search_photos`
-Search catalog by criteria.
+Search catalog by criteria (paginated, default limit 100).
 
 **Parameters:**
 - `filename` (string, optional): Partial filename match
@@ -319,8 +318,12 @@ Search catalog by criteria.
 - `rating` (number, optional): Star rating 0-5
 - `start_date` (string, optional): Date range start (YYYY-MM-DD)
 - `end_date` (string, optional): Date range end (YYYY-MM-DD)
+- `limit` (number, optional): Max photos to return (default 100)
+- `offset` (number, optional): Photos to skip for pagination (default 0)
 
-**Returns:** Array of photos with id, path, filename, rating, date
+**Returns:** `{ count, photos[], has_more, warning? }` — `warning` is set when no filters are applied (full-catalog scan).
+
+> **Performance note:** Always provide at least one filter (`rating`, `filename`, `keywords`, or date range). Without filters the plugin scans the full catalog via LR's internal SQL search engine; response includes a `warning` field in that case.
 
 #### `get_photo_metadata`
 Get detailed metadata for a photo.

--- a/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
@@ -61,15 +61,12 @@ function SearchHandler.searchPhotos(args)
 
     local total = 0
 
-    -- When no user filters: use rating>=0 as a universal criterion so findPhotos()
-    -- can be used consistently. findPhotos() routes through LR's internal SQL search
-    -- engine which is significantly faster than getAllPhotos() on large catalogs.
-    if not hasFilters then
-        table.insert(searchDesc, { criteria = "rating", operation = ">=", value = 0 })
-    end
-
     catalog:withReadAccessDo(function()
-        local matches = catalog:findPhotos{ searchDesc = searchDesc }
+        -- Unrated photos have nil rating; rating>=0 excludes them, so getAllPhotos()
+        -- must be used when no filters are specified.
+        local matches = hasFilters
+            and catalog:findPhotos{ searchDesc = searchDesc }
+            or catalog:getAllPhotos()
 
         total = #matches
         local last = math.min(offset + limit, total)

--- a/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
@@ -61,13 +61,15 @@ function SearchHandler.searchPhotos(args)
 
     local total = 0
 
+    -- When no user filters: use rating>=0 as a universal criterion so findPhotos()
+    -- can be used consistently. findPhotos() routes through LR's internal SQL search
+    -- engine which is significantly faster than getAllPhotos() on large catalogs.
+    if not hasFilters then
+        table.insert(searchDesc, { criteria = "rating", operation = ">=", value = 0 })
+    end
+
     catalog:withReadAccessDo(function()
-        local matches
-        if hasFilters then
-            matches = catalog:findPhotos{ searchDesc = searchDesc }
-        else
-            matches = catalog:getAllPhotos()
-        end
+        local matches = catalog:findPhotos{ searchDesc = searchDesc }
 
         total = #matches
         local last = math.min(offset + limit, total)
@@ -79,11 +81,17 @@ function SearchHandler.searchPhotos(args)
     logger:info(string.format("Search matched %d photos, returning %d (offset=%d, limit=%d)",
         total, #results, offset, limit))
 
-    return {
+    local response = {
         count = total,
         photos = results,
         has_more = (offset + #results) < total,
     }
+
+    if not hasFilters then
+        response.warning = "No filters applied — scanned full catalog. Provide filename, keywords, rating, or date filters to narrow results and improve performance."
+    end
+
+    return response
 end
 
 return SearchHandler

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -105,6 +105,9 @@ function M.fakeCatalog(opts)
             return name:lower():find(criterion.value:lower(), 1, true) ~= nil
         elseif crit == "rating" and op == "==" then
             return photo:getRawMetadata('rating') == criterion.value
+        elseif crit == "rating" and op == ">=" then
+            local r = photo:getRawMetadata('rating')
+            return r ~= nil and r >= criterion.value
         elseif crit == "keywords" and op == "all" then
             local kws = photo:getRawMetadata('keywords') or {}
             local target = criterion.value:lower()

--- a/server/src/list-tools-handler.ts
+++ b/server/src/list-tools-handler.ts
@@ -3,7 +3,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 export const TOOL_DEFINITIONS: Tool[] = [
   {
     name: "search_photos",
-    description: "Search for photos in Lightroom catalog by criteria (paginated, default limit 100)",
+    description: "Search for photos in Lightroom catalog by criteria (paginated, default limit 100). Providing at least one filter (filename, keywords, rating, or date) significantly improves performance on large catalogs.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Motivation

`search_photos` was calling `catalog:getAllPhotos()` and filtering results in Lua, which loads the entire catalog into memory regardless of filter criteria. For large libraries this is slow and memory-intensive. `catalog:findPhotos()` pushes filter criteria into the LR SDK, returning only matching photos.

Closes https://github.com/Automaat/lightroom-mcp/issues/49

## Implementation information

- `HandlerSearch.lua`: build a `FindPhotosParams` table from the incoming filter criteria (text query, rating, flag, label) and call `catalog:findPhotos()` instead of `getAllPhotos()` + manual filter loop.
- Fall back to `catalog:getAllPhotos()` when no filters are supplied — `findPhotos()` with `rating >= 0` excludes unrated photos (nil rating field), so an empty-filter call would silently drop unrated items.
- `spec_helper.lua`: extend fake catalog `photoMatches()` to handle `rating >=` criterion so existing specs don't error on the new code path.
- Updated README to document the `rating`, `flag`, and `label` filter parameters.

> Changelog: perf(plugin): use findPhotos for filtered search