### PR TITLE
refactor(server): tighten catch type guard in dispatcher

### DIFF
--- a/server/src/dispatcher.ts
+++ b/server/src/dispatcher.ts
@@ -36,8 +36,9 @@ export class Dispatcher {
     let resp: PluginResponse;
     try {
       resp = JSON.parse(line) as PluginResponse;
-    } catch {
-      this.log(`Bad JSON from plugin: ${line}`);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log(`Bad JSON from plugin (${msg}): ${line}`);
       return;
     }
     const p = this.pending.get(resp.id);


### PR DESCRIPTION
## Motivation

The `catch` block in dispatcher's JSON parse path swallowed the parse error silently, logging only the raw line. With `catch {}` (no binding), the actual error message was lost, making it harder to diagnose malformed plugin responses.

## Implementation information

- Bind `err: unknown` in the catch clause
- Narrow to `Error` instance to extract `.message`; fall back to `String(err)` for non-Error throws
- Include the parse error message in the log line alongside the raw payload

Closes https://github.com/Automaat/lightroom-mcp/issues/51