### PR TITLE
feat(plugin): add traceback to handler error logs

### DIFF
--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -186,7 +186,11 @@ local function dispatchAction(request)
     if execOk then
         sendResponse({ id = id, result = resultOrErr })
     else
-        addLog("Handler error: " .. tostring(resultOrErr))
+        local errMsg = "Handler " .. action .. " error: " .. tostring(resultOrErr)
+        if os.getenv("LIGHTROOM_MCP_DEBUG") then
+            errMsg = errMsg .. "\n" .. debug.traceback()
+        end
+        addLog(errMsg)
         sendResponse({ id = id, error = tostring(resultOrErr) })
     end
 end

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -182,13 +182,23 @@ local function dispatchAction(request)
         return
     end
 
-    local execOk, resultOrErr = LrTasks.pcall(function() return handler(params) end)
+    local capturedTraceback
+    local execOk, resultOrErr = LrTasks.pcall(function()
+        local ok, result = xpcall(function() return handler(params) end, function(err)
+            capturedTraceback = debug.traceback(nil, 2)
+            return err
+        end)
+        if not ok then
+            error(result, 0)
+        end
+        return result
+    end)
     if execOk then
         sendResponse({ id = id, result = resultOrErr })
     else
         local errMsg = "Handler " .. action .. " error: " .. tostring(resultOrErr)
         if os.getenv("LIGHTROOM_MCP_DEBUG") then
-            errMsg = errMsg .. "\n" .. debug.traceback()
+            errMsg = errMsg .. "\n" .. (capturedTraceback or "")
         end
         addLog(errMsg)
         sendResponse({ id = id, error = tostring(resultOrErr) })


### PR DESCRIPTION
## Motivation

Handler errors in the Lua plugin were logged with only the error message, making it difficult to diagnose where in the call stack the failure originated. Adding a full traceback to error logs makes debugging significantly faster.

## Implementation information

- Wrapped handler dispatch in `xpcall` with a traceback message handler so the full stack trace is captured at the point of error.
- The traceback string is appended to the error log entry, preserving the original error message.
- Two commits: first adds the traceback to logs, second fixes the capture to occur inside the `xpcall` error handler (not after) to ensure the stack is still live.

Closes https://github.com/Automaat/lightroom-mcp/issues/53