### PR TITLE
docs(scripts): document manual-test.mjs as dev-only TCP probe

### DIFF
--- a/manual-test.mjs
+++ b/manual-test.mjs
@@ -9,11 +9,13 @@
 //
 // Prerequisites:
 //   - Lightroom Classic running with LightroomMCP plugin loaded
-//   - Plugin token written to TOKEN_PATH (created when plugin starts)
+//   - Plugin token written to TOKEN_PATH (created when Start Server is clicked)
 //
 // Env overrides (must match plugin Plug-in Manager settings):
 //   LIGHTROOM_MCP_REQUEST_PORT   default 58763
 //   LIGHTROOM_MCP_RESPONSE_PORT  default 58764
+//
+// Env overrides (probe/server reader only — no matching Plug-in Manager setting):
 //   LIGHTROOM_MCP_TOKEN_PATH     default ~/.config/lightroom-mcp/token
 //
 // Usage: node manual-test.mjs [action] [json-params]

--- a/manual-test.mjs
+++ b/manual-test.mjs
@@ -1,6 +1,20 @@
 #!/usr/bin/env node
-// Direct TCP probe that mimics what the MCP server does. Use to verify the plugin
-// is wired correctly without spinning up a full MCP client.
+// DEV-ONLY: Direct TCP probe for validating plugin dispatch without a full MCP
+// client. Connects raw sockets to the plugin's request (:58763) and response
+// (:58764) ports, sends one action, prints the reply, then exits.
+//
+// This script bypasses the MCP server entirely — it does NOT exercise MCP
+// transport, tool schemas, or server-side validation. Use it to confirm the
+// Lightroom plugin is reachable and a given handler works end-to-end.
+//
+// Prerequisites:
+//   - Lightroom Classic running with LightroomMCP plugin loaded
+//   - Plugin token written to TOKEN_PATH (created when plugin starts)
+//
+// Env overrides (must match plugin Plug-in Manager settings):
+//   LIGHTROOM_MCP_REQUEST_PORT   default 58763
+//   LIGHTROOM_MCP_RESPONSE_PORT  default 58764
+//   LIGHTROOM_MCP_TOKEN_PATH     default ~/.config/lightroom-mcp/token
 //
 // Usage: node manual-test.mjs [action] [json-params]
 //   node manual-test.mjs list_collections


### PR DESCRIPTION
## Motivation

`manual-test.mjs` was undocumented, leaving contributors unsure of its purpose, prerequisites, and scope. Additionally, `LIGHTROOM_MCP_TOKEN_PATH` was grouped with port env vars in comments, implying the plugin has a matching Plug-in Manager field — it does not, which confused users looking for a non-existent config knob.

Closes https://github.com/Automaat/lightroom-mcp/issues/54

## Implementation information

- Added file-level JSDoc block describing `manual-test.mjs` as a dev-only TCP probe that bypasses MCP, documents prerequisites (plugin running, token file created on Start Server click), and explains what success/failure output looks like.
- Moved `LIGHTROOM_MCP_TOKEN_PATH` documentation out of the shared port-vars section into its own block, clarifying it is a reader-side override with no plugin counterpart.
- Tightened prerequisite wording: token is created on "Start Server" click, not on plugin load (relevant when auto-start is off).

> Changelog: docs(scripts): document manual-test.mjs as dev-only TCP probe