### PR TITLE
ci(actions): bump version in create-server.ts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,8 @@ jobs:
 
       - name: Bump server runtime version string
         run: |
-          sed -i -E 's/version: "[0-9]+\.[0-9]+\.[0-9]+"/version: "'"$VERSION"'"/' server/src/index.ts
-          grep -q "version: \"$VERSION\"" server/src/index.ts
+          sed -i -E 's/version: "[0-9]+\.[0-9]+\.[0-9]+"/version: "'"$VERSION"'"/' server/src/create-server.ts
+          grep -q "version: \"$VERSION\"" server/src/create-server.ts
 
       - name: Bump plugin Info.lua
         run: |
@@ -116,7 +116,7 @@ jobs:
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add server/package.json server/package-lock.json server/src/index.ts plugin/LightroomMCP.lrplugin/Info.lua
+          git add server/package.json server/package-lock.json server/src/create-server.ts plugin/LightroomMCP.lrplugin/Info.lua
           git commit -m "chore(release): v$VERSION"
           git tag "v$VERSION"
           git push origin HEAD:main


### PR DESCRIPTION
## Motivation

Release workflow run [25457737757](https://github.com/Automaat/lightroom-mcp/actions/runs/25457737757/job/74691602850) failed at "Bump server runtime version string". The `version: "X.Y.Z"` literal moved from `server/src/index.ts` to `server/src/create-server.ts` during the MCP server refactor, so the sed step matched nothing and the follow-up `grep -q` exited 1.

## Implementation information

- Point sed and grep at `server/src/create-server.ts`.
- Update the `git add` list in the commit step accordingly.

No alternatives — version literal is single-sourced; just chase the file move.

## Supporting documentation

> Changelog: skip