### PR TITLE
ci(actions): split plugin release artifacts per OS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,11 @@ jobs:
         working-directory: server
         run: npm pack
 
-      - name: Zip plugin bundle
+      - name: Zip plugin bundle (per platform)
         working-directory: plugin
-        run: zip -r ../LightroomMCP.lrplugin.zip LightroomMCP.lrplugin
+        run: |
+          zip -r ../LightroomMCP-macos.lrplugin.zip LightroomMCP.lrplugin
+          zip -r ../LightroomMCP-windows.lrplugin.zip LightroomMCP.lrplugin
 
       - name: Commit, tag, push
         run: |
@@ -127,7 +129,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "v$VERSION" \
-            LightroomMCP.lrplugin.zip \
+            LightroomMCP-macos.lrplugin.zip \
+            LightroomMCP-windows.lrplugin.zip \
             "server/lightroom-mcp-server-$VERSION.tgz" \
             --title "v$VERSION" \
             --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@ Run before every commit (CI runs the same):
 
 Copy `plugin/LightroomMCP.lrplugin/` to:
 - macOS: `~/Library/Application Support/Adobe/Lightroom/Plugins/`
+- Windows: `%APPDATA%\Adobe\Lightroom\Plugins\`
+
+Bundle is pure Lua — same content ships in both `LightroomMCP-macos.lrplugin.zip` and `LightroomMCP-windows.lrplugin.zip` release artifacts. Split is for download UX, not platform code.
 
 Click **Start Server** in Plug-in Manager. Logs at `~/Documents/LrClassicLogs/LightroomMCP.log`.
 


### PR DESCRIPTION
## Motivation

One neutral `LightroomMCP.lrplugin.zip` on the release page makes
Windows users wonder whether the asset is Mac-only. Want clearly
labeled per-OS downloads.

## Implementation information

- Release workflow now zips the same `plugin/LightroomMCP.lrplugin/`
  bundle twice with platform-suffixed names and attaches both to the
  GitHub release alongside the server tgz.
- Bundle stays pure Lua, no `WIN_ENV`/`MAC_ENV` branches, so the two
  zips are byte-identical. Split is for download UX only.
- CLAUDE.md gains the Windows install path
  (`%APPDATA%\Adobe\Lightroom\Plugins\`) and a note that the artifacts
  are content-identical so future readers don't assume a platform
  split exists in the Lua code.

Alternative considered: keep one zip, rename to
`LightroomMCP.lrplugin.zip` and rely on README. Rejected — release
page is where users land first; filename signals platform support.

> Changelog: ci(actions): split plugin release artifacts per OS