### PR TITLE
ci(actions): use npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
-      - name: Setup Node.js (with npm registry auth)
+      - name: Setup Node.js (npm registry)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '25'
@@ -229,17 +229,18 @@ jobs:
           cache: npm
           cache-dependency-path: server/package-lock.json
 
+      - name: Ensure npm CLI supports trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install + build
         working-directory: server
         run: |
           npm ci --ignore-scripts
           npx tsc
 
-      - name: Publish to npm with provenance
+      - name: Publish via npm trusted publishing (OIDC)
         working-directory: server
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
+        run: npm publish
 
   publish:
     name: Publish GitHub release

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pick the path that matches your AI assistant.
 
 ### Claude Desktop / Claude Code (1-click)
 
-1. Download `lightroom-mcp-<version>.mcpb` from [Releases](https://github.com/skalskimarcin/lightroom-mcp/releases/latest).
+1. Download `lightroom-mcp-<version>.mcpb` from [Releases](https://github.com/Automaat/lightroom-mcp/releases/latest).
 2. Double-click the file. Claude installs it.
 3. The bundled Lightroom plugin auto-installs into Lightroom's Modules folder on first run. Restart Lightroom Classic once.
 4. In Lightroom: **File → Plug-in Manager → Lightroom MCP → Start Server**.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/skalskimarcin/lightroom-mcp"
+    "url": "https://github.com/Automaat/lightroom-mcp"
   },
   "license": "MIT",
   "keywords": ["lightroom", "lightroom-classic", "photography", "adobe"],

--- a/server/README.md
+++ b/server/README.md
@@ -6,7 +6,7 @@ MCP server bridging Claude / Codex / Cursor to Adobe Lightroom Classic via a bun
 
 ### Claude Desktop / Claude Code (one-click)
 
-Grab the `.mcpb` from [GitHub Releases](https://github.com/skalskimarcin/lightroom-mcp/releases/latest) and double-click. The Lightroom plugin auto-installs on first run.
+Grab the `.mcpb` from [GitHub Releases](https://github.com/Automaat/lightroom-mcp/releases/latest) and double-click. The Lightroom plugin auto-installs on first run.
 
 ### Codex CLI
 
@@ -45,7 +45,7 @@ lightroom-mcp install-plugin     Copy plugin into Lightroom Modules folder
 ## Docs and source
 
 Full documentation, architecture notes, and the Lightroom plugin live at
-<https://github.com/skalskimarcin/lightroom-mcp>.
+<https://github.com/Automaat/lightroom-mcp>.
 
 ## License
 

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "lightroom-mcp": "dist/index.js"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "dist",
@@ -35,14 +36,14 @@
   ],
   "author": "Marcin Skalski",
   "license": "MIT",
-  "homepage": "https://github.com/skalskimarcin/lightroom-mcp#readme",
+  "homepage": "https://github.com/Automaat/lightroom-mcp#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/skalskimarcin/lightroom-mcp.git",
+    "url": "git+https://github.com/Automaat/lightroom-mcp.git",
     "directory": "server"
   },
   "bugs": {
-    "url": "https://github.com/skalskimarcin/lightroom-mcp/issues"
+    "url": "https://github.com/Automaat/lightroom-mcp/issues"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Motivation

Long-lived `NPM_TOKEN` is a secret-management liability. npm Trusted
Publishing (GA July 2025) lets CI publish via OIDC — no token needed,
provenance attestations free.

## Implementation information

Workflow:
- `permissions.id-token: write` already in place on publish-npm job.
- Upgrade npm CLI to latest before publish (TP needs >=11.5.1; Node 25
  ships older).
- Drop `NODE_AUTH_TOKEN` and the `--access`/`--provenance` flags from
  the publish command — both are now declared in `publishConfig`.
- Tighten command to `npm publish` (auth via OIDC).

`server/package.json`:
- `publishConfig.provenance: true` — forces provenance attestation.
- `repository.url` corrected from `skalskimarcin/lightroom-mcp` to
  `Automaat/lightroom-mcp`. **This must match the Trusted Publisher
  config exactly or npm rejects the OIDC token.**
- README/manifest links updated to the same URL.

## Bootstrap problem (one-time, manual)

npm Trusted Publishing requires the package to **already exist** on
the registry before TP can be configured. So:

1. Locally, `cd server && npm publish` from the @mskalski account.
   This is the single time a personal token is used. Cuts `0.2.0`.
2. On https://www.npmjs.com/package/@automaat/lightroom-mcp/access:
   - Add Trusted Publisher → GitHub Actions
   - Organization: `Automaat`
   - Repository: `lightroom-mcp`
   - Workflow filename: `release.yml`
   - Environment: leave blank
3. From then on, every `gh workflow run release.yml` publishes
   automatically with provenance, no token.

## Supporting documentation

- npm trusted publishing docs: https://docs.npmjs.com/trusted-publishers/
- GitHub Actions OIDC GA: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- "Things you need to do for npm trusted publishing to work" (philna.sh)