### PR TITLE
chore(release): rename npm scope to @mskalski

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
             lightroom-mcp-*.mcpb
             LightroomMCP-macos.lrplugin.zip
             LightroomMCP-windows.lrplugin.zip
-            server/automaat-lightroom-mcp-*.tgz
+            server/mskalski-lightroom-mcp-*.tgz
           retention-days: 7
 
   build-binaries:
@@ -272,7 +272,7 @@ jobs:
             "lightroom-mcp-${VERSION}.mcpb" \
             LightroomMCP-macos.lrplugin.zip \
             LightroomMCP-windows.lrplugin.zip \
-            "automaat-lightroom-mcp-${VERSION}.tgz" \
+            "mskalski-lightroom-mcp-${VERSION}.tgz" \
             lightroom-mcp-darwin-arm64 \
             lightroom-mcp-darwin-x64 \
             lightroom-mcp-windows-x64.exe \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ That's it. No Node.js, no terminal, no JSON editing.
 ### Codex CLI
 
 ```bash
-codex mcp add lightroom -- npx -y @automaat/lightroom-mcp
+codex mcp add lightroom -- npx -y @mskalski/lightroom-mcp
 ```
 
 Or with the standalone binary if Node isn't available:
@@ -36,7 +36,7 @@ Add to the client's MCP config:
   "mcpServers": {
     "lightroom": {
       "command": "npx",
-      "args": ["-y", "@automaat/lightroom-mcp"]
+      "args": ["-y", "@mskalski/lightroom-mcp"]
     }
   }
 }
@@ -45,7 +45,7 @@ Add to the client's MCP config:
 Then install the Lightroom plugin once:
 
 ```bash
-npx -y @automaat/lightroom-mcp install-plugin
+npx -y @mskalski/lightroom-mcp install-plugin
 ```
 
 ### Manual install (any client)

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-# @automaat/lightroom-mcp
+# @mskalski/lightroom-mcp
 
 MCP server bridging Claude / Codex / Cursor to Adobe Lightroom Classic via a bundled Lua plugin.
 
@@ -11,13 +11,13 @@ Grab the `.mcpb` from [GitHub Releases](https://github.com/Automaat/lightroom-mc
 ### Codex CLI
 
 ```bash
-codex mcp add lightroom -- npx -y @automaat/lightroom-mcp
+codex mcp add lightroom -- npx -y @mskalski/lightroom-mcp
 ```
 
 Then install the Lightroom plugin once:
 
 ```bash
-npx -y @automaat/lightroom-mcp install-plugin
+npx -y @mskalski/lightroom-mcp install-plugin
 ```
 
 ### Cursor / Windsurf / VS Code
@@ -29,7 +29,7 @@ Add to MCP config:
   "mcpServers": {
     "lightroom": {
       "command": "npx",
-      "args": ["-y", "@automaat/lightroom-mcp"]
+      "args": ["-y", "@mskalski/lightroom-mcp"]
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@automaat/lightroom-mcp",
+  "name": "@mskalski/lightroom-mcp",
   "version": "0.2.0",
   "description": "MCP server bridging Claude/Codex/ChatGPT to Adobe Lightroom Classic via a Lua plugin.",
   "type": "module",


### PR DESCRIPTION
## Motivation

Switch npm scope from `@automaat` (would need org creation) to
`@mskalski` (personal account). Less friction, fewer accounts.

## Implementation information

- `server/package.json` name → `@mskalski/lightroom-mcp`
- README install snippets updated
- Release workflow: tarball glob and gh release upload list updated
  to `mskalski-lightroom-mcp-*.tgz`
- TP config unchanged: GitHub repo is still `Automaat/lightroom-mcp`,
  only the npm scope changes. The TP entry on npm will be added under
  `https://www.npmjs.com/package/@mskalski/lightroom-mcp/access`.