### PR TITLE
fix(release): drop provenance from publishConfig

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,8 +8,7 @@
     "lightroom-mcp": "dist/index.js"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Motivation

Local bootstrap publish (needed once before npm Trusted Publishing
can be configured) failed with:

```
npm error code EUSAGE
npm error Automatic provenance generation not supported for provider: null
```

`publishConfig.provenance: true` forces the flag on every publish,
but provenance only works from trusted CI providers.

## Implementation information

Drop the `provenance` key from `publishConfig`. With Trusted
Publishing configured on the package, `npm publish` from GHA
generates provenance automatically (per npm docs):

> When you publish using trusted publishing from GitHub Actions
> or GitLab CI/CD, npm automatically generates and publishes
> provenance attestations for your package — you don't need to
> add the --provenance flag.

Local bootstrap now also works as plain `npm publish`.