### PR TITLE
fix(actions): flatten tarball path before upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,9 +149,10 @@ jobs:
           zip -r ../LightroomMCP-macos.lrplugin.zip LightroomMCP.lrplugin
           zip -r ../LightroomMCP-windows.lrplugin.zip LightroomMCP.lrplugin
 
-      - name: Rename .mcpb with version suffix
+      - name: Stage release artifacts at repo root
         run: |
           cp build/lightroom-mcp.mcpb "lightroom-mcp-${VERSION}.mcpb"
+          cp server/mskalski-lightroom-mcp-*.tgz .
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -160,7 +161,7 @@ jobs:
             lightroom-mcp-*.mcpb
             LightroomMCP-macos.lrplugin.zip
             LightroomMCP-windows.lrplugin.zip
-            server/mskalski-lightroom-mcp-*.tgz
+            mskalski-lightroom-mcp-*.tgz
           retention-days: 7
 
   build-binaries:


### PR DESCRIPTION
## Motivation

Release v0.3.0 publish-npm succeeded (package on npm), but the GH
release upload failed with `no matches found for
mskalski-lightroom-mcp-0.3.0.tgz`. v0.3.0 release was recovered
manually; this prevents the same failure on v0.3.1+.

## Implementation information

`actions/upload-artifact` preserves directory structure relative to
the working dir, so `server/mskalski-lightroom-mcp-*.tgz` was
uploaded with the `server/` prefix and downloaded as
`release-artifacts/server/...`. The publish job's `gh release
create` looked for it at `release-artifacts/...` and failed.

Fix: copy the tarball to repo root before upload, same as the
.mcpb staging step. All release assets are now flat at root.

## Supporting documentation

n/a