### PR TITLE
fix(deps): patch audit vulnerabilities

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2580,9 +2580,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2880,9 +2880,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.17",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
-      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Motivation

`npm audit` reported one high (`fast-uri`) and one moderate (`hono`) vulnerability in the transitive dependency graph.

Closes #92

> Changelog: fix(deps): patch audit vulnerabilities

## Implementation information

Ran `npm audit fix --package-lock-only` in `server/`:

- `fast-uri` 3.1.0 -> 3.1.2 — path traversal (GHSA-q3j6-qgpj-74h6), host confusion (GHSA-v39h-62p7-jpjc)
- `hono` 4.12.17 -> 4.12.18 — CSS declaration injection, JWT NumericDate validation, cache cross-user leakage

Lockfile-only change; no `package.json` range edits needed.

## Supporting documentation

Verification:
- `npm audit` — 0 findings
- `npx tsc --noEmit` — passes
- `npm test -- --ci` — 98 tests pass