### PR TITLE
docs(agents): add codex guidance symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Motivation

Codex reads AGENTS.md by default. Existing guidance lives in CLAUDE.md.

> Changelog: docs(agents): add codex guidance symlink

## Implementation information

Add AGENTS.md as symlink to CLAUDE.md. One source of truth.

## Supporting documentation

None.