### PR TITLE
ci(actions): restrict workflow tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build & Test (${{ matrix.os }})

--- a/.github/workflows/lua-lint.yml
+++ b/.github/workflows/lua-lint.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   luacheck:
     name: Lint Lightroom plugin (Lua)

--- a/.github/workflows/lua-test.yml
+++ b/.github/workflows/lua-test.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   busted:
     name: Run busted specs


### PR DESCRIPTION
## Motivation

Closes #93. CI, Lua lint, and Lua test workflows had no explicit `permissions` block, so they inherited repository default token scopes — broader rights than each job needs, increasing token blast radius.

> Changelog: skip

## Implementation information

Added top-level `permissions: contents: read` to:

- `.github/workflows/ci.yml`
- `.github/workflows/lua-lint.yml`
- `.github/workflows/lua-test.yml`

These jobs only checkout and run build/lint/test — read access is sufficient. Elevated permissions left untouched where required: CodeQL `security-events: write` (job-level), release `contents: write` (top-level), npm publish `id-token: write` (job-level).

## Supporting documentation

Issue #93 (parent #91).