### PR TITLE
build(tooling): restore local Lua test tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Node.js
 node_modules/
+
+# Lua (project-local LuaRocks tree)
+lua_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,11 @@
 [tools]
 node = "24"
 bun = "1.3.14"
+lua = "5.4"
+
+[env]
+# Project-local LuaRocks tree (busted, luacheck) installed by `lua:deps`.
+_.path = ["lua_modules/bin"]
 
 [tasks.install]
 description = "Install dependencies"
@@ -25,3 +30,20 @@ run = "node scripts/build-mcpb.mjs"
 [tasks.binary]
 description = "Build single-file binaries (macos + windows) via Bun"
 run = "node scripts/build-binary.mjs"
+
+[tasks."lua:deps"]
+description = "Install Lua test/lint rocks (busted, luacheck) into lua_modules/"
+run = '''
+test -x lua_modules/bin/busted   || luarocks install --tree lua_modules busted
+test -x lua_modules/bin/luacheck || luarocks install --tree lua_modules luacheck
+'''
+
+[tasks."lua:test"]
+description = "Run busted specs for the Lightroom plugin"
+depends = ["lua:deps"]
+run = "busted"
+
+[tasks."lua:lint"]
+description = "Lint the Lightroom plugin with luacheck"
+depends = ["lua:deps"]
+run = "luacheck plugin --no-color --codes"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,10 @@ Use mise tasks from repo root:
 - `mise run build` — `tsc` (outputs `server/dist/`)
 - `mise run test` — Jest (ESM via ts-jest)
 - `mise run dev` — `tsc --watch`
+- `mise run lua:lint` — `luacheck plugin --no-color --codes`
+- `mise run lua:test` — `busted` specs for the plugin
 
-Lua: `luacheck plugin --no-color --codes` (CI runs this; `.luacheckrc` declares LR SDK globals, excludes `JSON.lua`).
+Lua tooling: `mise install` provisions `lua` + `luarocks`; `lua:lint`/`lua:test` auto-install `luacheck`/`busted` into `lua_modules/` (gitignored) via the `lua:deps` task. `.luacheckrc` declares LR SDK globals, excludes `JSON.lua`.
 
 ## CI
 
@@ -45,7 +47,8 @@ Run before every commit (CI runs the same):
 - `cd server && npx tsc --noEmit` — type check must pass
 - `mise run build` — `tsc` compile must succeed
 - `mise run test` — Jest suite must pass
-- `luacheck plugin --no-color --codes` — only if Lua changed
+- `mise run lua:lint` — only if Lua changed
+- `mise run lua:test` — only if Lua changed
 
 ## Plugin install (manual, no automation)
 

--- a/README.md
+++ b/README.md
@@ -209,13 +209,14 @@ The plugin generates a 256-bit token in `~/.config/lightroom-mcp/token` on **Sta
 ## Develop
 
 ```bash
-mise install                        # tools (node, bun)
+mise install                        # tools (node, bun, lua + luarocks)
 mise run install                    # npm ci
 mise run build                      # tsc
 mise run test                       # jest
 mise run mcpb                       # build .mcpb bundle
 mise run binary                     # build single-file binaries via Bun
-luacheck plugin --no-color --codes  # lint Lua plugin
+mise run lua:lint                   # luacheck the Lua plugin
+mise run lua:test                   # busted specs for the Lua plugin
 ```
 
 Repo layout:


### PR DESCRIPTION
## Motivation

Local Lua validation is documented, but `busted` and `luacheck` were not
available locally — plugin changes relied on CI for any feedback. Closes #94.

> Changelog: build(tooling): restore local Lua test tools

## Implementation information

- Add `lua = "5.4"` to `.mise.toml` `[tools]`; the mise lua plugin also
  provisions `luarocks` on PATH.
- `lua:deps` task installs `busted` + `luacheck` into a gitignored
  project-local `lua_modules/` tree (`luarocks --tree`); guarded by
  `test -x` so it is idempotent and cheap on repeat runs.
- `lua:test` runs `busted`, `lua:lint` runs `luacheck plugin --no-color
  --codes`; both `depends = ["lua:deps"]` so they self-bootstrap after a
  fresh `mise install`.
- `lua_modules/` added to `.gitignore`.
- README and CLAUDE.md command lists updated to the mise task names.

Alternative discarded: a `postinstall` mise hook to install rocks during
`mise install` — hooks are experimental and would force every contributor
to enable `experimental=true`. The `depends` chain achieves the same
bootstrap without that.

Verified fresh: `mise install`, `mise run lua:lint` (0 warnings / 14
files), `mise run lua:test` (70 successes).

## Supporting documentation

Issue #94 (parent #91).