### PR TITLE
test(ts): typecheck Jest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm ci
 
       - name: Type check
-        run: npx tsc --noEmit
+        run: npm run check
 
       - name: Build
         run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,13 +38,13 @@ Lua tooling: `mise install` provisions `lua` + `luarocks`; `lua:lint`/`lua:test`
 
 - `.github/workflows/ci.yml` — build+test on ubuntu/macos/windows, Node 22.
 - `.github/workflows/lua-lint.yml` — luacheck on plugin changes.
-- Type check uses `tsc --noEmit`; do not break it.
+- Type check runs `npm run check` (`tsc --noEmit` on src + `tsconfig.test.json` on tests); do not break it.
 
 ## Pre-commit checklist
 
 Run before every commit (CI runs the same):
 
-- `cd server && npx tsc --noEmit` — type check must pass
+- `cd server && npm run check` — type check (src + tests) must pass
 - `mise run build` — `tsc` compile must succeed
 - `mise run test` — Jest suite must pass
 - `mise run lua:lint` — only if Lua changed

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -10,6 +10,9 @@ export default {
       'ts-jest',
       {
         useESM: true,
+        // 151002 recommends `isolatedModules: true`, which is incompatible
+        // with ts-jest's ESM transform (breaks `import` emit). tsconfig.test.json
+        // is the real type gate for tests; this warning is noise here.
         diagnostics: { ignoreCodes: [151002] },
       },
     ],

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "watch": "tsc --watch",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/server/tsconfig.test.json
+++ b/server/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Motivation

`tsc --noEmit` excluded `tests/`, and `ts-jest` ran with a diagnostic
ignore — so test-only type regressions never hit the type gate.

> Changelog: test(ts): typecheck Jest tests

Closes #95

## Implementation information

- Add `server/tsconfig.test.json` extending the main config, `noEmit`,
  `include: ["src/**/*", "tests/**/*"]`, `rootDir: "."`.
- Add `check` script: `tsc --noEmit && tsc -p tsconfig.test.json`.
- CI Type Check step now runs `npm run check`.
- Kept `diagnostics.ignoreCodes: [151002]` in `jest.config.js`: the
  warning recommends `isolatedModules: true`, which breaks ts-jest's
  ESM `import` emit. `tsconfig.test.json` is the real test type gate;
  added a comment explaining why the ignore stays.

Verified the new config catches a deliberate test-file type error.

## Supporting documentation

Issue #95