### PR TITLE
test(coverage): enforce server jest thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm test -- --ci --reporters=default
+        run: npm run test:coverage -- --ci --reporters=default
 
       - name: Upload build artifacts
         if: matrix.os == 'ubuntu-latest'

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -19,4 +19,22 @@ export default {
   },
   testMatch: ['**/tests/**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts'],
+  // Ratchet: raise these as coverage climbs. `index.ts` is the bin entrypoint
+  // (socket + stdio wiring) and is not unit-tested yet — issue #97 step 4
+  // tracks covering it before its threshold is lifted off the floor. A path
+  // entry is subtracted from `global`, so `global` covers every other file.
+  coverageThreshold: {
+    global: {
+      statements: 94,
+      branches: 87,
+      functions: 90,
+      lines: 95,
+    },
+    './src/index.ts': {
+      statements: 0,
+      branches: 0,
+      functions: 0,
+      lines: 0,
+    },
+  },
 };

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     "watch": "tsc --watch",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage --runInBand",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },

--- a/server/tests/install-plugin.test.ts
+++ b/server/tests/install-plugin.test.ts
@@ -1,18 +1,117 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { findBundledPlugin, installPlugin, lightroomModulesDir } from '../src/install-plugin.js';
+import {
+  ensurePluginInstalled,
+  findBundledPlugin,
+  installPlugin,
+  isPluginInstalledAnywhere,
+  lightroomModulesDir,
+  lightroomPluginsDir,
+} from '../src/install-plugin.js';
+
+const realPlatform = process.platform;
+const realAppData = process.env.APPDATA;
+
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+}
+
+function restoreEnv(): void {
+  Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+  if (realAppData === undefined) delete process.env.APPDATA;
+  else process.env.APPDATA = realAppData;
+  jest.restoreAllMocks();
+}
 
 describe('lightroomModulesDir', () => {
+  afterEach(restoreEnv);
+
   it('returns a darwin path on macOS', () => {
-    if (process.platform !== 'darwin') return;
-    expect(lightroomModulesDir()).toMatch(/Library\/Application Support\/Adobe\/Lightroom\/Modules$/);
+    setPlatform('darwin');
+    expect(lightroomModulesDir()).toMatch(
+      /Library\/Application Support\/Adobe\/Lightroom\/Modules$/,
+    );
   });
 
-  it('returns a Windows path on win32', () => {
-    if (process.platform !== 'win32') return;
+  it('returns an APPDATA-based path on win32', () => {
+    setPlatform('win32');
+    process.env.APPDATA = path.join('C:', 'Users', 'tester', 'AppData', 'Roaming');
     expect(lightroomModulesDir()).toMatch(/Adobe[\\/]+Lightroom[\\/]+Modules$/);
+    expect(lightroomModulesDir()).toContain(process.env.APPDATA);
+  });
+
+  it('falls back to homedir AppData on win32 when APPDATA unset', () => {
+    setPlatform('win32');
+    delete process.env.APPDATA;
+    expect(lightroomModulesDir()).toMatch(/AppData[\\/]+Roaming[\\/]+Adobe/);
+  });
+
+  it('returns an XDG-style path on linux', () => {
+    setPlatform('linux');
+    expect(lightroomModulesDir()).toMatch(/\.local\/share\/Adobe\/Lightroom\/Modules$/);
+  });
+});
+
+describe('lightroomPluginsDir', () => {
+  afterEach(restoreEnv);
+
+  it('returns a darwin path on macOS', () => {
+    setPlatform('darwin');
+    expect(lightroomPluginsDir()).toMatch(
+      /Library\/Application Support\/Adobe\/Lightroom\/Plugins$/,
+    );
+  });
+
+  it('returns an APPDATA-based path on win32', () => {
+    setPlatform('win32');
+    process.env.APPDATA = path.join('C:', 'Users', 'tester', 'AppData', 'Roaming');
+    expect(lightroomPluginsDir()).toMatch(/Adobe[\\/]+Lightroom[\\/]+Plugins$/);
+  });
+
+  it('falls back to homedir AppData on win32 when APPDATA unset', () => {
+    setPlatform('win32');
+    delete process.env.APPDATA;
+    expect(lightroomPluginsDir()).toMatch(/AppData[\\/]+Roaming[\\/]+Adobe/);
+  });
+
+  it('returns an XDG-style path on linux', () => {
+    setPlatform('linux');
+    expect(lightroomPluginsDir()).toMatch(/\.local\/share\/Adobe\/Lightroom\/Plugins$/);
+  });
+});
+
+describe('isPluginInstalledAnywhere', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'lrmcp-home-'));
+    setPlatform('linux');
+    jest.spyOn(os, 'homedir').mockReturnValue(home);
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('returns false when no plugin is present', () => {
+    expect(isPluginInstalledAnywhere()).toBe(false);
+  });
+
+  it('returns true when Info.lua is present in the modules dir', () => {
+    const dir = path.join(lightroomModulesDir(), 'LightroomMCP.lrplugin');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'Info.lua'), '-- fake');
+    expect(isPluginInstalledAnywhere()).toBe(true);
+  });
+
+  it('returns true when Info.lua is present in the plugins dir', () => {
+    const dir = path.join(lightroomPluginsDir(), 'LightroomMCP.lrplugin');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'Info.lua'), '-- fake');
+    expect(isPluginInstalledAnywhere()).toBe(true);
   });
 });
 
@@ -43,6 +142,34 @@ describe('installPlugin', () => {
       expect(result.status).toBe('installed');
       expect(fs.existsSync(path.join(result.destination, 'Info.lua'))).toBe(true);
       expect(fs.existsSync(path.join(result.destination, 'Handler.lua'))).toBe(true);
+    } finally {
+      fs.rmSync(sourceParent, { recursive: true, force: true });
+    }
+  });
+
+  it('copies nested directories recursively', () => {
+    const sourceParent = fs.mkdtempSync(path.join(os.tmpdir(), 'lrmcp-src-'));
+    try {
+      const source = makeFakePlugin(sourceParent);
+      fs.mkdirSync(path.join(source, 'sub'));
+      fs.writeFileSync(path.join(source, 'sub', 'Nested.lua'), '-- nested');
+      const result = installPlugin({ source, destDir: tmp });
+      expect(fs.existsSync(path.join(result.destination, 'sub', 'Nested.lua'))).toBe(true);
+    } finally {
+      fs.rmSync(sourceParent, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves symlinks when copying', () => {
+    if (process.platform === 'win32') return;
+    const sourceParent = fs.mkdtempSync(path.join(os.tmpdir(), 'lrmcp-src-'));
+    try {
+      const source = makeFakePlugin(sourceParent);
+      fs.symlinkSync('Info.lua', path.join(source, 'Info.link.lua'));
+      const result = installPlugin({ source, destDir: tmp });
+      const copied = path.join(result.destination, 'Info.link.lua');
+      expect(fs.lstatSync(copied).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(copied)).toBe('Info.lua');
     } finally {
       fs.rmSync(sourceParent, { recursive: true, force: true });
     }
@@ -118,5 +245,65 @@ describe('findBundledPlugin', () => {
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe('ensurePluginInstalled', () => {
+  let home: string;
+  let startDir: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'lrmcp-home-'));
+    startDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lrmcp-start-'));
+    setPlatform('linux');
+    jest.spyOn(os, 'homedir').mockReturnValue(home);
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(startDir, { recursive: true, force: true });
+  });
+
+  function bundlePluginIn(dir: string): void {
+    const src = path.join(dir, 'LightroomMCP.lrplugin');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'Info.lua'), '-- fake');
+  }
+
+  it('returns early without logging when a plugin is already installed', () => {
+    const installed = path.join(lightroomModulesDir(), 'LightroomMCP.lrplugin');
+    fs.mkdirSync(installed, { recursive: true });
+    fs.writeFileSync(path.join(installed, 'Info.lua'), '-- fake');
+    const log = jest.fn();
+    ensurePluginInstalled(startDir, log);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no bundled plugin can be found', () => {
+    const log = jest.fn();
+    ensurePluginInstalled(startDir, log);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('installs the bundled plugin and logs progress', () => {
+    bundlePluginIn(startDir);
+    const log = jest.fn();
+    ensurePluginInstalled(startDir, log);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('copied'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('restart Lightroom'));
+    expect(
+      fs.existsSync(path.join(lightroomModulesDir(), 'LightroomMCP.lrplugin', 'Info.lua')),
+    ).toBe(true);
+  });
+
+  it('logs a failure message when the install throws', () => {
+    bundlePluginIn(startDir);
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {
+      throw new Error('disk full');
+    });
+    const log = jest.fn();
+    ensurePluginInstalled(startDir, log);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('failed: disk full'));
   });
 });

--- a/server/tests/install-plugin.test.ts
+++ b/server/tests/install-plugin.test.ts
@@ -30,27 +30,29 @@ describe('lightroomModulesDir', () => {
 
   it('returns a darwin path on macOS', () => {
     setPlatform('darwin');
-    expect(lightroomModulesDir()).toMatch(
-      /Library\/Application Support\/Adobe\/Lightroom\/Modules$/,
-    );
+    expect(lightroomModulesDir().endsWith(
+      path.join('Library', 'Application Support', 'Adobe', 'Lightroom', 'Modules'),
+    )).toBe(true);
   });
 
   it('returns an APPDATA-based path on win32', () => {
     setPlatform('win32');
     process.env.APPDATA = path.join('C:', 'Users', 'tester', 'AppData', 'Roaming');
-    expect(lightroomModulesDir()).toMatch(/Adobe[\\/]+Lightroom[\\/]+Modules$/);
+    expect(lightroomModulesDir().endsWith(path.join('Adobe', 'Lightroom', 'Modules'))).toBe(true);
     expect(lightroomModulesDir()).toContain(process.env.APPDATA);
   });
 
   it('falls back to homedir AppData on win32 when APPDATA unset', () => {
     setPlatform('win32');
     delete process.env.APPDATA;
-    expect(lightroomModulesDir()).toMatch(/AppData[\\/]+Roaming[\\/]+Adobe/);
+    expect(lightroomModulesDir()).toContain(path.join('AppData', 'Roaming', 'Adobe'));
   });
 
   it('returns an XDG-style path on linux', () => {
     setPlatform('linux');
-    expect(lightroomModulesDir()).toMatch(/\.local\/share\/Adobe\/Lightroom\/Modules$/);
+    expect(lightroomModulesDir().endsWith(
+      path.join('.local', 'share', 'Adobe', 'Lightroom', 'Modules'),
+    )).toBe(true);
   });
 });
 
@@ -59,26 +61,28 @@ describe('lightroomPluginsDir', () => {
 
   it('returns a darwin path on macOS', () => {
     setPlatform('darwin');
-    expect(lightroomPluginsDir()).toMatch(
-      /Library\/Application Support\/Adobe\/Lightroom\/Plugins$/,
-    );
+    expect(lightroomPluginsDir().endsWith(
+      path.join('Library', 'Application Support', 'Adobe', 'Lightroom', 'Plugins'),
+    )).toBe(true);
   });
 
   it('returns an APPDATA-based path on win32', () => {
     setPlatform('win32');
     process.env.APPDATA = path.join('C:', 'Users', 'tester', 'AppData', 'Roaming');
-    expect(lightroomPluginsDir()).toMatch(/Adobe[\\/]+Lightroom[\\/]+Plugins$/);
+    expect(lightroomPluginsDir().endsWith(path.join('Adobe', 'Lightroom', 'Plugins'))).toBe(true);
   });
 
   it('falls back to homedir AppData on win32 when APPDATA unset', () => {
     setPlatform('win32');
     delete process.env.APPDATA;
-    expect(lightroomPluginsDir()).toMatch(/AppData[\\/]+Roaming[\\/]+Adobe/);
+    expect(lightroomPluginsDir()).toContain(path.join('AppData', 'Roaming', 'Adobe'));
   });
 
   it('returns an XDG-style path on linux', () => {
     setPlatform('linux');
-    expect(lightroomPluginsDir()).toMatch(/\.local\/share\/Adobe\/Lightroom\/Plugins$/);
+    expect(lightroomPluginsDir().endsWith(
+      path.join('.local', 'share', 'Adobe', 'Lightroom', 'Plugins'),
+    )).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Motivation

Closes #97. Jest collected coverage but never enforced it, so entrypoint/install changes could silently lower coverage. `index.ts` sat at 0% and `install-plugin.ts` at ~58%.

## Implementation information

- `jest.config.js`: add `coverageThreshold`. `global` floor (statements 94 / branches 87 / functions 90 / lines 95) matches the current non-entrypoint baseline. A per-file entry for `./src/index.ts` is subtracted from `global`, so its untested bin wiring sits at a floor of 0 without dragging the global gate down — issue #97 step 4 tracks covering it before lifting that floor.
- `install-plugin.test.ts`: cover the gaps — platform path branches for `lightroomModulesDir`/`lightroomPluginsDir`, `isPluginInstalledAnywhere`, `ensurePluginInstalled` (already-installed / no-source / install / failure), and the symlink copy path. `install-plugin.ts` is now ~98% lines.
- `package.json`: add `test:coverage` (`jest --coverage --runInBand`).
- `ci.yml`: the Test step now runs `test:coverage`, so thresholds gate every PR.

## Supporting documentation

Issue #97 (parent #91).

> Changelog: skip