### PR TITLE
Fix JSON escaping for Windows paths

### DIFF
--- a/plugin/LightroomMCP.lrplugin/JSON.lua
+++ b/plugin/LightroomMCP.lrplugin/JSON.lua
@@ -5,7 +5,7 @@ function JSON:encode(obj)
     local function encode_value(v)
         local t = type(v)
         if t == "string" then
-            return '"' .. v:gsub('"', '\\"'):gsub('\n', '\\n'):gsub('\r', '\\r'):gsub('\t', '\\t') .. '"'
+            return '"' .. v:gsub('\\', '\\\\'):gsub('"', '\\"'):gsub('\n', '\\n'):gsub('\r', '\\r'):gsub('\t', '\\t') .. '"'
         elseif t == "number" or t == "boolean" then
             return tostring(v)
         elseif t == "table" then
@@ -57,7 +57,7 @@ function JSON:decode(str)
                 end
             end
             local value = str:sub(start, pos - 1)
-            value = value:gsub('\\n', '\n'):gsub('\\r', '\r'):gsub('\\t', '\t'):gsub('\\"', '"')
+            value = value:gsub('\\n', '\n'):gsub('\\r', '\r'):gsub('\\t', '\t'):gsub('\\"', '"'):gsub('\\\\', '\\')
             pos = pos + 1
             return value
         elseif char == '{' then

--- a/plugin/LightroomMCP.lrplugin/JSON.lua
+++ b/plugin/LightroomMCP.lrplugin/JSON.lua
@@ -48,18 +48,36 @@ function JSON:decode(str)
         if char == '"' then
             -- String
             pos = pos + 1
-            local start = pos
-            while pos <= #str and str:sub(pos, pos) ~= '"' do
-                if str:sub(pos, pos) == '\\' then
+            local chars = {}
+            while pos <= #str do
+                local current = str:sub(pos, pos)
+                if current == '"' then
+                    pos = pos + 1
+                    return table.concat(chars)
+                elseif current == '\\' then
+                    local escaped = str:sub(pos + 1, pos + 1)
+                    if escaped == '"' or escaped == '\\' or escaped == '/' then
+                        table.insert(chars, escaped)
+                    elseif escaped == 'n' then
+                        table.insert(chars, '\n')
+                    elseif escaped == 'r' then
+                        table.insert(chars, '\r')
+                    elseif escaped == 't' then
+                        table.insert(chars, '\t')
+                    elseif escaped == 'b' then
+                        table.insert(chars, string.char(8))
+                    elseif escaped == 'f' then
+                        table.insert(chars, string.char(12))
+                    else
+                        error("Invalid escape sequence: \\" .. tostring(escaped))
+                    end
                     pos = pos + 2
                 else
+                    table.insert(chars, current)
                     pos = pos + 1
                 end
             end
-            local value = str:sub(start, pos - 1)
-            value = value:gsub('\\n', '\n'):gsub('\\r', '\r'):gsub('\\t', '\t'):gsub('\\"', '"'):gsub('\\\\', '\\')
-            pos = pos + 1
-            return value
+            error("Unterminated string")
         elseif char == '{' then
             -- Object
             pos = pos + 1

--- a/plugin/spec/JSON_spec.lua
+++ b/plugin/spec/JSON_spec.lua
@@ -1,0 +1,17 @@
+local JSON = require 'JSON'
+
+describe("JSON", function()
+    it("escapes Windows path backslashes when encoding strings", function()
+        local encoded = JSON:encode({
+            path = "C:\\gvv\\Photos\\Archve\\Source\\_GVV2154.NEF",
+        })
+
+        assert.is_not_nil(encoded:find('"path":"C:\\\\gvv\\\\Photos\\\\Archve\\\\Source\\\\_GVV2154.NEF"', 1, true))
+    end)
+
+    it("decodes escaped Windows path backslashes in strings", function()
+        local decoded = JSON:decode('{"path":"C:\\\\gvv\\\\Photos\\\\Archve\\\\Source\\\\_GVV2154.NEF"}')
+
+        assert.are.equal("C:\\gvv\\Photos\\Archve\\Source\\_GVV2154.NEF", decoded.path)
+    end)
+end)

--- a/plugin/spec/JSON_spec.lua
+++ b/plugin/spec/JSON_spec.lua
@@ -3,15 +3,21 @@ local JSON = require 'JSON'
 describe("JSON", function()
     it("escapes Windows path backslashes when encoding strings", function()
         local encoded = JSON:encode({
-            path = "C:\\gvv\\Photos\\Archve\\Source\\_GVV2154.NEF",
+            path = "C:\\gvv\\Photos\\Archive\\Source\\_GVV2154.NEF",
         })
 
-        assert.is_not_nil(encoded:find('"path":"C:\\\\gvv\\\\Photos\\\\Archve\\\\Source\\\\_GVV2154.NEF"', 1, true))
+        assert.is_not_nil(encoded:find('"path":"C:\\\\gvv\\\\Photos\\\\Archive\\\\Source\\\\_GVV2154.NEF"', 1, true))
     end)
 
     it("decodes escaped Windows path backslashes in strings", function()
-        local decoded = JSON:decode('{"path":"C:\\\\gvv\\\\Photos\\\\Archve\\\\Source\\\\_GVV2154.NEF"}')
+        local decoded = JSON:decode('{"path":"C:\\\\gvv\\\\Photos\\\\Archive\\\\Source\\\\_GVV2154.NEF"}')
 
-        assert.are.equal("C:\\gvv\\Photos\\Archve\\Source\\_GVV2154.NEF", decoded.path)
+        assert.are.equal("C:\\gvv\\Photos\\Archive\\Source\\_GVV2154.NEF", decoded.path)
+    end)
+
+    it("does not treat escaped Windows path letters as JSON control escapes", function()
+        local decoded = JSON:decode('{"path":"C:\\\\new\\\\test\\\\raw"}')
+
+        assert.are.equal("C:\\new\\test\\raw", decoded.path)
     end)
 end)


### PR DESCRIPTION
## Summary
- Escape backslashes when the Lightroom plugin JSON encoder serializes strings.
- Decode escaped backslashes back to `\` in JSON request strings.
- Add Lua specs covering Windows photo paths like `C:\gvv\Photos\...\_GVV2154.NEF`.

## Why
On Windows, plugin responses from tools such as `search_photos` and `get_selected_photos` can include raw paths like `C:\...`. Without escaping backslashes, the Node bridge receives invalid JSON and logs errors like:

```text
Bad JSON from plugin (JSON Parse error: Invalid escape character ...)
```

I reproduced this with a Lightroom catalog on Windows. After applying this change locally:

- `search_photos` returned valid JSON with a Windows path.
- `export_photos` succeeded using the returned path.
- `get_selected_photos` returned valid JSON.

## Validation
- `cd server && npm run check`
- `cd server && npm test`
- `cd server && npm run lint`

Not run locally: `mise run lua:test` because this Windows machine does not have `mise`, `lua`, or `busted` installed. The PR adds a Lua spec for CI to run.