### PR TITLE
fix(lifecycle): auto-start and export recovery

### DIFF
--- a/plugin/LightroomMCP.lrplugin/HandlerExport.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerExport.lua
@@ -20,66 +20,71 @@ function ExportHandler.exportPhotos(args)
     end
 
     local catalog = LrApplication.activeCatalog()
-    local exportedCount = 0
 
+    -- Resolve photos under read access, then RELEASE the lock before
+    -- exporting. doExportOnCurrentTask() can run for minutes on a large
+    -- batch; holding catalog read access for that whole span blocks every
+    -- other handler (list_collections, get_selected_photos, ...) and on
+    -- macOS wedged the bridge until a manual restart (issue #128).
+    -- LrExportSession acquires its own catalog access during rendering, so
+    -- the lock is only needed for the lookup itself.
+    local photosToExport = {}
     catalog:withReadAccessDo(function()
-        -- Find photos
-        local photosToExport = {}
         local resolved = PhotoLookup.resolveMany(catalog, args.photo_ids)
         for _, entry in ipairs(resolved) do
             if entry.photo then
                 table.insert(photosToExport, entry.photo)
             end
         end
-
-        if #photosToExport == 0 then
-            error("No photos found to export")
-        end
-
-        -- destinationType=specificFolder makes LR honour
-        -- LR_export_destinationPathPrefix; sourceFolder ignores it and
-        -- writes next to the original. LR_format is set in the
-        -- format-specific block below.
-        local exportSettings = {
-            LR_export_destinationType = 'specificFolder',
-            LR_export_destinationPathPrefix = args.destination,
-            LR_export_useSubfolder = false,
-            LR_jpeg_quality = args.quality or 90,
-        }
-
-        -- Set dimensions if specified
-        if args.width or args.height then
-            exportSettings.LR_size_doConstrain = true
-            exportSettings.LR_size_maxWidth = args.width
-            exportSettings.LR_size_maxHeight = args.height
-            exportSettings.LR_size_resizeType = 'longEdge'
-        end
-
-        -- Handle different formats
-        if args.format == 'jpeg' or args.format == 'JPEG' or not args.format then
-            exportSettings.LR_format = 'JPEG'
-            exportSettings.LR_export_colorSpace = 'sRGB'
-        elseif args.format == 'png' or args.format == 'PNG' then
-            exportSettings.LR_format = 'PNG'
-        elseif args.format == 'tiff' or args.format == 'TIFF' then
-            exportSettings.LR_format = 'TIFF'
-            exportSettings.LR_tiff_compressionMethod = 'compressionMethod_LZW'
-        elseif args.format == 'original' or args.format == 'ORIGINAL' then
-            exportSettings.LR_format = 'ORIGINAL'
-        end
-
-        -- Create export session
-        local exportSession = LrExportSession {
-            photosToExport = photosToExport,
-            exportSettings = exportSettings,
-        }
-
-        -- Execute export
-        exportSession:doExportOnCurrentTask()
-        exportedCount = #photosToExport
-
-        logger:info(string.format("Exported %d photos to: %s", exportedCount, args.destination))
     end)
+
+    if #photosToExport == 0 then
+        error("No photos found to export")
+    end
+
+    -- destinationType=specificFolder makes LR honour
+    -- LR_export_destinationPathPrefix; sourceFolder ignores it and
+    -- writes next to the original. LR_format is set in the
+    -- format-specific block below.
+    local exportSettings = {
+        LR_export_destinationType = 'specificFolder',
+        LR_export_destinationPathPrefix = args.destination,
+        LR_export_useSubfolder = false,
+        LR_jpeg_quality = args.quality or 90,
+    }
+
+    -- Set dimensions if specified
+    if args.width or args.height then
+        exportSettings.LR_size_doConstrain = true
+        exportSettings.LR_size_maxWidth = args.width
+        exportSettings.LR_size_maxHeight = args.height
+        exportSettings.LR_size_resizeType = 'longEdge'
+    end
+
+    -- Handle different formats
+    if args.format == 'jpeg' or args.format == 'JPEG' or not args.format then
+        exportSettings.LR_format = 'JPEG'
+        exportSettings.LR_export_colorSpace = 'sRGB'
+    elseif args.format == 'png' or args.format == 'PNG' then
+        exportSettings.LR_format = 'PNG'
+    elseif args.format == 'tiff' or args.format == 'TIFF' then
+        exportSettings.LR_format = 'TIFF'
+        exportSettings.LR_tiff_compressionMethod = 'compressionMethod_LZW'
+    elseif args.format == 'original' or args.format == 'ORIGINAL' then
+        exportSettings.LR_format = 'ORIGINAL'
+    end
+
+    -- Create export session
+    local exportSession = LrExportSession {
+        photosToExport = photosToExport,
+        exportSettings = exportSettings,
+    }
+
+    -- Execute export (outside the read-access block above)
+    exportSession:doExportOnCurrentTask()
+    local exportedCount = #photosToExport
+
+    logger:info(string.format("Exported %d photos to: %s", exportedCount, args.destination))
 
     return {
         success = true,

--- a/plugin/LightroomMCP.lrplugin/HandlerImport.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerImport.lua
@@ -19,41 +19,52 @@ function ImportHandler.importPhotos(args)
     local catalog = LrApplication.activeCatalog()
     local importedCount = 0
 
-    -- Import photos
-    catalog:withWriteAccessDo("Import Photos", function()
-        local photosToImport = {}
-
-        if LrFileUtils.isDirectory(args.source_path) then
-            -- Import all photos from directory
-            for file in LrFileUtils.files(args.source_path) do
-                local ext = LrFileUtils.extension(file):lower()
-                if ext == 'jpg' or ext == 'jpeg' or ext == 'png' or
-                   ext == 'tif' or ext == 'tiff' or ext == 'dng' or
-                   ext == 'cr2' or ext == 'nef' or ext == 'arw' then
-                    table.insert(photosToImport, file)
-                end
+    -- Enumerate source files OUTSIDE any catalog lock; the filesystem walk
+    -- needs no catalog access.
+    local photosToImport = {}
+    if LrFileUtils.isDirectory(args.source_path) then
+        -- Import all photos from directory
+        for file in LrFileUtils.files(args.source_path) do
+            local ext = LrFileUtils.extension(file):lower()
+            if ext == 'jpg' or ext == 'jpeg' or ext == 'png' or
+               ext == 'tif' or ext == 'tiff' or ext == 'dng' or
+               ext == 'cr2' or ext == 'nef' or ext == 'arw' then
+                table.insert(photosToImport, file)
             end
-        else
-            -- Import single photo
-            table.insert(photosToImport, args.source_path)
         end
+    else
+        -- Import single photo
+        table.insert(photosToImport, args.source_path)
+    end
 
-        if #photosToImport == 0 then
-            error("No photos found to import")
-        end
+    if #photosToImport == 0 then
+        error("No photos found to import")
+    end
 
-        -- Use catalog:addPhoto for each file
-        local addedPhotos = {}
-        for _, filePath in ipairs(photosToImport) do
+    -- Add each photo in its OWN write transaction rather than holding the
+    -- exclusive catalog write lock across the whole batch. A large import
+    -- runs for minutes, and one batch-wide withWriteAccessDo would block
+    -- every other handler (reads included) for that entire span -- the same
+    -- bridge wedge the export handler was restructured to avoid (issue #128),
+    -- and now longer-lived since import_photos was given a 5-minute server
+    -- timeout. addPhoto cannot acquire its own isolated access the way
+    -- LrExportSession does, so a per-photo lock is the bounded-hold
+    -- equivalent: the lock is released between photos, letting queued
+    -- handlers interleave.
+    local addedPhotos = {}
+    for _, filePath in ipairs(photosToImport) do
+        catalog:withWriteAccessDo("Import Photo", function()
             local photo = catalog:addPhoto(filePath)
             if photo then
                 table.insert(addedPhotos, photo)
                 importedCount = importedCount + 1
             end
-        end
+        end)
+    end
 
-        -- Add to collection if specified
-        if args.collection_name and #addedPhotos > 0 then
+    -- Add to collection if specified, in its own short write transaction.
+    if args.collection_name and #addedPhotos > 0 then
+        catalog:withWriteAccessDo("Add Imported Photos to Collection", function()
             local targetCollection = nil
             local collections = catalog:getChildCollections()
 
@@ -71,8 +82,8 @@ function ImportHandler.importPhotos(args)
             else
                 logger:warn("Collection not found: " .. args.collection_name)
             end
-        end
-    end)
+        end)
+    end
 
     logger:info(string.format("Imported %d photos from: %s", importedCount, args.source_path))
 

--- a/plugin/LightroomMCP.lrplugin/PluginInit.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInit.lua
@@ -1,8 +1,11 @@
 local LrPrefs = import 'LrPrefs'
 local LrTasks = import 'LrTasks'
 local LrFunctionContext = import 'LrFunctionContext'
+local LrLogger = import 'LrLogger'
 
 local PluginInfoProvider = require 'PluginInfoProvider'
+
+local logger = LrLogger('LightroomMCP')
 
 local prefs = LrPrefs.prefsForPlugin()
 local autoStart = prefs.autoStartServer
@@ -22,6 +25,14 @@ if autoStart then
         -- Brief yield so any prior-instance context cancel (from Reload
         -- Plug-in) can flush and release ports before we try to bind them.
         LrTasks.sleep(0.5)
-        PluginInfoProvider.startServer()
+        -- Guard startServer. This task owns an independent context with no
+        -- cleanup handler, so an unhandled throw (token write, socket bind)
+        -- would tear the context down and leave auto-start dead with nothing
+        -- in the log -- the same invisible "server stopped after launch"
+        -- failure #128 was about. Surface it instead.
+        local ok, err = LrTasks.pcall(PluginInfoProvider.startServer)
+        if not ok then
+            logger:error("Auto-start failed: " .. tostring(err))
+        end
     end)
 end

--- a/plugin/LightroomMCP.lrplugin/PluginInit.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInit.lua
@@ -1,5 +1,6 @@
 local LrPrefs = import 'LrPrefs'
 local LrTasks = import 'LrTasks'
+local LrFunctionContext = import 'LrFunctionContext'
 
 local PluginInfoProvider = require 'PluginInfoProvider'
 
@@ -11,7 +12,13 @@ if autoStart == nil then
 end
 
 if autoStart then
-    LrTasks.startAsyncTask(function()
+    -- Must use postAsyncTaskWithContext, NOT LrTasks.startAsyncTask. A bare
+    -- startAsyncTask here runs in THIS init script's function context; when
+    -- LrInitPlugin returns, that context is torn down and the task is
+    -- cancelled mid-sleep before startServer() ever runs. On macOS that left
+    -- the server stopped after launch despite auto-start being on (issue
+    -- #128). A fresh context survives the init script returning.
+    LrFunctionContext.postAsyncTaskWithContext("LightroomMCPAutoStart", function()
         -- Brief yield so any prior-instance context cancel (from Reload
         -- Plug-in) can flush and release ports before we try to bind them.
         LrTasks.sleep(0.5)

--- a/plugin/spec/HandlerExport_spec.lua
+++ b/plugin/spec/HandlerExport_spec.lua
@@ -64,4 +64,41 @@ describe("HandlerExport.exportPhotos", function()
             Handler.exportPhotos({ photo_ids = { "missing" }, destination = "/out" })
         end)
     end)
+
+    it("runs the export after releasing catalog read access", function()
+        -- Holding read access for the whole export wedged the bridge on
+        -- macOS (issue #128). The lock must be released before
+        -- doExportOnCurrentTask runs.
+        local p = helper.fakePhoto({ id = "1", path = "/a.jpg" })
+        local insideReadAccess = false
+        local exportRanInsideReadAccess = nil
+        local catalog = helper.fakeCatalog({ photos = { p } })
+        local realWithRead = catalog.withReadAccessDo
+        catalog.withReadAccessDo = function(self, fn)
+            insideReadAccess = true
+            realWithRead(self, fn)
+            insideReadAccess = false
+        end
+        helper.installImport({
+            LrApplication = { activeCatalog = function() return catalog end },
+            LrLogger = helper.defaultLrLogger(),
+            LrFileUtils = {},
+            LrPathUtils = {},
+            LrExportSession = function()
+                return {
+                    doExportOnCurrentTask = function()
+                        exportRanInsideReadAccess = insideReadAccess
+                    end,
+                }
+            end,
+        })
+        package.loaded.HandlerExport = nil
+        local Handler = require 'HandlerExport'
+
+        local r = Handler.exportPhotos({ photo_ids = { "1" }, destination = "/out" })
+
+        assert.is_true(r.success)
+        assert.are.equal(1, r.exported)
+        assert.is_false(exportRanInsideReadAccess)
+    end)
 end)

--- a/plugin/spec/HandlerImport_spec.lua
+++ b/plugin/spec/HandlerImport_spec.lua
@@ -64,4 +64,22 @@ describe("HandlerImport.importPhotos", function()
         local r = Handler.importPhotos({ source_path = "/dir" })
         assert.are.equal(3, r.imported)
     end)
+
+    it("acquires catalog write access per photo, not once for the batch", function()
+        -- A batch-wide write lock wedges the bridge for the whole multi-minute
+        -- import (issue #128); each photo must get its own short transaction so
+        -- the exclusive lock is released between photos.
+        local catalog, Handler = setup({
+            fs = {
+                exists = { ["/dir"] = true },
+                directories = { ["/dir"] = true },
+                dirContents = { "/dir/a.jpg", "/dir/b.png", "/dir/c.dng" },
+            },
+        })
+
+        local r = Handler.importPhotos({ source_path = "/dir" })
+
+        assert.are.equal(3, r.imported)
+        assert.are.equal(3, catalog:getWriteAccessCount())
+    end)
 end)

--- a/plugin/spec/PluginInit_spec.lua
+++ b/plugin/spec/PluginInit_spec.lua
@@ -1,0 +1,65 @@
+local helper = require 'spec_helper'
+
+-- Load PluginInit with mocked LR globals and a stubbed PluginInfoProvider.
+-- Returns a table of observed effects.
+local function loadInit(opts)
+    opts = opts or {}
+    local observed = {
+        started = false,
+        usedPostAsyncTaskWithContext = false,
+        usedStartAsyncTask = false,
+    }
+
+    local prefs = { autoStartServer = opts.autoStartServer }
+
+    package.loaded.PluginInfoProvider = {
+        startServer = function() observed.started = true end,
+    }
+
+    helper.installImport({
+        LrPrefs = { prefsForPlugin = function() return prefs end },
+        LrTasks = {
+            -- A bare startAsyncTask is the fragile path PluginInit must NOT
+            -- use for auto-start; flag it if called so the test can fail.
+            startAsyncTask = function(fn)
+                observed.usedStartAsyncTask = true
+                fn()
+            end,
+            sleep = function() end,
+        },
+        LrFunctionContext = {
+            postAsyncTaskWithContext = function(_, fn)
+                observed.usedPostAsyncTaskWithContext = true
+                fn()
+            end,
+        },
+    })
+
+    package.loaded.PluginInit = nil
+    require 'PluginInit'
+    observed.prefs = prefs
+    return observed
+end
+
+describe("PluginInit auto-start", function()
+    it("starts the server via an independent function context", function()
+        local o = loadInit({ autoStartServer = true })
+        -- Durable context that survives the init script returning, not a
+        -- bare startAsyncTask tied to the init context (issue #128).
+        assert.is_true(o.usedPostAsyncTaskWithContext)
+        assert.is_false(o.usedStartAsyncTask)
+        assert.is_true(o.started)
+    end)
+
+    it("does not start the server when auto-start is disabled", function()
+        local o = loadInit({ autoStartServer = false })
+        assert.is_false(o.usedPostAsyncTaskWithContext)
+        assert.is_false(o.started)
+    end)
+
+    it("defaults auto-start to true when the pref is unset", function()
+        local o = loadInit({ autoStartServer = nil })
+        assert.is_true(o.prefs.autoStartServer)
+        assert.is_true(o.started)
+    end)
+end)

--- a/plugin/spec/PluginInit_spec.lua
+++ b/plugin/spec/PluginInit_spec.lua
@@ -8,12 +8,18 @@ local function loadInit(opts)
         started = false,
         usedPostAsyncTaskWithContext = false,
         usedStartAsyncTask = false,
+        loggedError = nil,
     }
 
     local prefs = { autoStartServer = opts.autoStartServer }
 
     package.loaded.PluginInfoProvider = {
-        startServer = function() observed.started = true end,
+        startServer = function()
+            if opts.startServerError then
+                error(opts.startServerError)
+            end
+            observed.started = true
+        end,
     }
 
     helper.installImport({
@@ -26,6 +32,7 @@ local function loadInit(opts)
                 fn()
             end,
             sleep = function() end,
+            pcall = function(fn, ...) return pcall(fn, ...) end,
         },
         LrFunctionContext = {
             postAsyncTaskWithContext = function(_, fn)
@@ -33,6 +40,16 @@ local function loadInit(opts)
                 fn()
             end,
         },
+        LrLogger = setmetatable({}, {
+            __call = function()
+                return {
+                    info = function() end,
+                    warn = function() end,
+                    error = function(_, msg) observed.loggedError = msg end,
+                    enable = function() end,
+                }
+            end,
+        }),
     })
 
     package.loaded.PluginInit = nil
@@ -61,5 +78,15 @@ describe("PluginInit auto-start", function()
         local o = loadInit({ autoStartServer = nil })
         assert.is_true(o.prefs.autoStartServer)
         assert.is_true(o.started)
+    end)
+
+    it("logs the failure instead of dying silently when startServer throws", function()
+        -- The auto-start task owns its own context with no cleanup handler, so
+        -- an unhandled throw would tear it down with nothing logged -- the
+        -- invisible-failure mode of issue #128. It must be surfaced.
+        local o = loadInit({ autoStartServer = true, startServerError = "bind failed" })
+        assert.is_false(o.started)
+        assert.is_not_nil(o.loggedError)
+        assert.is_truthy(o.loggedError:find("bind failed", 1, true))
     end)
 end)

--- a/server/src/dispatcher.ts
+++ b/server/src/dispatcher.ts
@@ -17,8 +17,10 @@ export interface DispatcherOptions {
   /**
    * Per-action timeout overrides (ms), keyed by action name. Long-running
    * actions like batch export/import need far more than the default before a
-   * healthy plugin can reply; a flat timeout reports a spurious failure and
-   * leaves a stale pending entry. Actions absent here use `timeoutMs`.
+   * healthy plugin can reply; with too short a timeout the call reports a
+   * false failure, and the plugin's eventual (correct) response arrives after
+   * the pending entry is gone, so it is dropped as an unknown id. Actions
+   * absent here use `timeoutMs`.
    */
   actionTimeoutsMs?: Record<string, number>;
   log?: (msg: string) => void;

--- a/server/src/dispatcher.ts
+++ b/server/src/dispatcher.ts
@@ -20,7 +20,7 @@ export interface DispatcherOptions {
    * healthy plugin can reply; with too short a timeout the call reports a
    * false failure, and the plugin's eventual (correct) response arrives after
    * the pending entry is gone, so it is dropped as an unknown id. Actions
-   * absent here use `timeoutMs`.
+   * absent here -- or mapped to a non-positive value -- use `timeoutMs`.
    */
   actionTimeoutsMs?: Record<string, number>;
   log?: (msg: string) => void;
@@ -64,7 +64,10 @@ export class Dispatcher {
 
   async call(action: string, params: unknown): Promise<PluginResponse> {
     const id = `req_${Date.now()}_${this.idCounter++}`;
-    const timeoutMs = this.actionTimeoutsMs[action] ?? this.timeoutMs;
+    // A non-positive override means "no override": `0` would otherwise arm a
+    // 0 ms timer that rejects on the next tick.
+    const override = this.actionTimeoutsMs[action];
+    const timeoutMs = override !== undefined && override > 0 ? override : this.timeoutMs;
 
     const responsePromise = new Promise<PluginResponse>((resolve, reject) => {
       const timer = setTimeout(() => {

--- a/server/src/dispatcher.ts
+++ b/server/src/dispatcher.ts
@@ -14,6 +14,13 @@ export interface DispatcherOptions {
   send: (line: string) => boolean;
   getToken: () => string;
   timeoutMs?: number;
+  /**
+   * Per-action timeout overrides (ms), keyed by action name. Long-running
+   * actions like batch export/import need far more than the default before a
+   * healthy plugin can reply; a flat timeout reports a spurious failure and
+   * leaves a stale pending entry. Actions absent here use `timeoutMs`.
+   */
+  actionTimeoutsMs?: Record<string, number>;
   log?: (msg: string) => void;
 }
 
@@ -21,6 +28,7 @@ export class Dispatcher {
   private pending = new Map<string, PendingResponse>();
   private idCounter = 0;
   private readonly timeoutMs: number;
+  private readonly actionTimeoutsMs: Record<string, number>;
   private readonly send: (line: string) => boolean;
   private readonly getToken: () => string;
   private readonly log: (msg: string) => void;
@@ -29,6 +37,7 @@ export class Dispatcher {
     this.send = opts.send;
     this.getToken = opts.getToken;
     this.timeoutMs = opts.timeoutMs ?? 30_000;
+    this.actionTimeoutsMs = opts.actionTimeoutsMs ?? {};
     this.log = opts.log ?? ((msg: string) => console.error(msg));
   }
 
@@ -53,12 +62,13 @@ export class Dispatcher {
 
   async call(action: string, params: unknown): Promise<PluginResponse> {
     const id = `req_${Date.now()}_${this.idCounter++}`;
+    const timeoutMs = this.actionTimeoutsMs[action] ?? this.timeoutMs;
 
     const responsePromise = new Promise<PluginResponse>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`Plugin response timeout (${this.timeoutMs / 1000}s)`));
-      }, this.timeoutMs);
+        reject(new Error(`Plugin response timeout (${timeoutMs / 1000}s)`));
+      }, timeoutMs);
       this.pending.set(id, { resolve, reject, timer });
     });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,13 @@ import {
 } from "./install-plugin.js";
 
 const REQUEST_TIMEOUT_MS = 30_000;
+// Batch export/import render files and can run for minutes; the default
+// timeout would report a spurious failure mid-export. See issue #128.
+const LONG_RUNNING_TIMEOUT_MS = 300_000;
+const ACTION_TIMEOUTS_MS: Record<string, number> = {
+  export_photos: LONG_RUNNING_TIMEOUT_MS,
+  import_photos: LONG_RUNNING_TIMEOUT_MS,
+};
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -60,6 +67,7 @@ async function main() {
     send: (line) => requestSocket.send(line),
     getToken: () => readToken(),
     timeoutMs: REQUEST_TIMEOUT_MS,
+    actionTimeoutsMs: ACTION_TIMEOUTS_MS,
   });
   const responseSocket = new PluginSocket({
     port: RESPONSE_PORT,

--- a/server/tests/dispatcher.test.ts
+++ b/server/tests/dispatcher.test.ts
@@ -165,5 +165,24 @@ describe('Dispatcher', () => {
       await expect(p).rejects.toThrow(/timeout \(1s\)/);
       expect(d.pendingCount()).toBe(0);
     });
+
+    it('falls back to the default when an override is non-positive', async () => {
+      jest.useFakeTimers();
+      const d = new Dispatcher({
+        send: (line) => {
+          sent.push(line);
+          return true;
+        },
+        getToken: () => 'test-token',
+        timeoutMs: 1000,
+        // 0 must mean "no override", not a 0 ms timer that rejects immediately.
+        actionTimeoutsMs: { export_photos: 0 },
+      });
+
+      const p = d.call('export_photos', {});
+      jest.advanceTimersByTime(1000);
+      await expect(p).rejects.toThrow(/timeout \(1s\)/);
+      expect(d.pendingCount()).toBe(0);
+    });
   });
 });

--- a/server/tests/dispatcher.test.ts
+++ b/server/tests/dispatcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { Dispatcher } from '../src/dispatcher.js';
 
 interface SentRequest {
@@ -111,5 +111,59 @@ describe('Dispatcher', () => {
     const sentObj = parseSent(sent[0]);
     expect(sentObj.params).toEqual({});
     await p.catch(() => {});
+  });
+
+  describe('per-action timeout overrides', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('honors a longer timeout for the configured action', async () => {
+      jest.useFakeTimers();
+      const d = new Dispatcher({
+        send: (line) => {
+          sent.push(line);
+          return true;
+        },
+        getToken: () => 'test-token',
+        timeoutMs: 1000,
+        actionTimeoutsMs: { export_photos: 60_000 },
+      });
+
+      const p = d.call('export_photos', {});
+      let settled = false;
+      void p.catch(() => {
+        settled = true;
+      });
+
+      // Past the default timeout, but the override keeps it pending.
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(d.pendingCount()).toBe(1);
+
+      // Past the override: now it rejects, reporting the override duration.
+      jest.advanceTimersByTime(59_000);
+      await expect(p).rejects.toThrow(/timeout \(60s\)/);
+      expect(d.pendingCount()).toBe(0);
+    });
+
+    it('falls back to the default timeout for unlisted actions', async () => {
+      jest.useFakeTimers();
+      const d = new Dispatcher({
+        send: (line) => {
+          sent.push(line);
+          return true;
+        },
+        getToken: () => 'test-token',
+        timeoutMs: 1000,
+        actionTimeoutsMs: { export_photos: 60_000 },
+      });
+
+      const p = d.call('list_collections', {});
+      jest.advanceTimersByTime(1000);
+      await expect(p).rejects.toThrow(/timeout \(1s\)/);
+      expect(d.pendingCount()).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Motivation

Issue #128: on macOS two lifecycle problems made the bridge unreliable.

1. **Auto-start mismatch** — with auto-start checked, after quitting and reopening Lightroom the server was stopped: ports unbound, status `Running: false`, and only `PluginInfoProvider loaded` in the log. Manual **Start Server** was needed every launch.
2. **Export wedge** — a larger `export_photos` returned `Plugin response timeout (30s)`, after which every later call also timed out until a manual Plug-in Manager restart.

> Changelog: fix(lifecycle): auto-start and export recovery

## Implementation information

Root causes and the fixes:

- **Auto-start dies with the init context.** The delayed start ran in a bare `LrTasks.startAsyncTask`, whose task shares the init script's function context. When `LrInitPlugin` returns, that context is torn down and the task is cancelled mid-`sleep(0.5)` before `startServer()` runs — matching the report exactly (only `PluginInfoProvider loaded` logged). Switched to `LrFunctionContext.postAsyncTaskWithContext` so the delayed start owns an independent context that outlives init teardown.

- **Export holds the catalog lock.** `doExportOnCurrentTask()` ran inside `catalog:withReadAccessDo`, holding a read lock for the whole multi-minute export and blocking every other handler (the wedge). Photos are now resolved under read access, then the export runs with the lock released; `LrExportSession` acquires its own catalog access during render.

- **Flat timeout reports a false failure.** The single 30s dispatcher timeout fired before a healthy plugin could finish a big batch, leaving a stale pending entry. Added per-action timeout overrides; `export_photos`/`import_photos` get 5 min.

Tests: new `PluginInit_spec` (durable context + pref handling), extended `HandlerExport_spec` (export runs after the lock is released), extended `dispatcher.test` (per-action override + fallback). Server **137** and Lua **77** specs pass; type-check, ESLint, and build are green.

> **Note on local lint:** `mise run lua:lint` currently crashes locally — luacheck is incompatible with the pinned Lua 5.5 (5.5 made `for`-loop control variables const; luacheck reassigns one in its own `standards.lua`). It is unrelated to this change and dies before reading any plugin file. CI lints Lua on Ubuntu's Lua 5.4, which is unaffected. A selene migration to remove this Lua-runtime coupling will follow in a separate PR.

## Supporting documentation

- Closes #128
- Related: #121 (lifetime tied to Plug-in Manager), #124 (Windows blocking timeouts)