### PR TITLE
fix(plugin): run photo queries outside read gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Plugin opens **two LrSocket binds** as servers; MCP server connects to both.
 - Plugin allows **one client per port at a time**. MCP server holds a persistent connection.
 - `LrSocket.bind` in `mode='receive'` has a 10s no-client timeout that fires `onError`. Plugin auto-calls `:reconnect()` from a monitor loop in response. Reconnect storms are prevented by setting flags in callbacks and acting on them in the loop (never `:reconnect()` synchronously from `onError`).
 - `onMessage` runs in non-yielding context — handler dispatch must be wrapped in `LrTasks.startAsyncTask` so `catalog:withReadAccessDo` can yield.
+- Catalog queries that yield (`getTargetPhotos`, `findPhotos`) must run **outside** `withReadAccessDo`. Nesting a yielding query inside the read gate deadlocks on Windows: the task yields to the UI thread holding the gate, never returns, never releases it, wedging the bridge until the server timeout (#124/#134). Only non-yielding per-photo metadata reads belong inside the gate. `getAllPhotos` is a non-yielding enumeration, safe either side. Specs guard this via `getQueriedInsideReadAccess()` in `spec_helper`.
 
 Pattern verified against MIDI2LR (`rsjaffe/MIDI2LR`, see `src/plugin/Client.lua`) — same dual-port LrSocket model, ports 58763/58764 also chosen there.
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ Logs:
 | Plugin | `~/Documents/LrClassicLogs/LightroomMCP.log` | `%USERPROFILE%\Documents\LrClassicLogs\LightroomMCP.log` |
 | Claude Desktop | `~/Library/Logs/Claude/mcp*.log` | `%APPDATA%\Claude\Logs\mcp*.log` |
 
+The plugin resolves its log path via the OS (`LrPathUtils`), so on Windows with
+OneDrive-redirected Documents the file follows the redirect. The exact resolved
+path is shown as **Log file:** in Plug-in Manager → **Show Status** — use that if
+the table path above is empty.
+
 ## License
 
 MIT

--- a/plugin/LightroomMCP.lrplugin/HandlerCollections.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerCollections.lua
@@ -1,9 +1,7 @@
 local LrApplication = import 'LrApplication'
-local LrLogger = import 'LrLogger'
 
 local PhotoLookup = require 'PhotoLookup'
-
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 local CollectionsHandler = {}
 
@@ -52,7 +50,7 @@ function CollectionsHandler.listCollections(args)
         table.insert(slice, all[i])
     end
 
-    logger:info(string.format("Found %d collections, returning %d (offset=%d, limit=%d)",
+    Log.info(string.format("Found %d collections, returning %d (offset=%d, limit=%d)",
         total, #slice, offset, limit))
 
     return {
@@ -72,7 +70,7 @@ function CollectionsHandler.createCollection(args)
 
     catalog:withWriteAccessDo("Create Collection", function()
         catalog:createCollection(collectionName)
-        logger:info("Created collection: " .. collectionName)
+        Log.info("Created collection: " .. collectionName)
     end)
 
     return {
@@ -154,7 +152,7 @@ function CollectionsHandler.addToCollection(args)
         end
     end)
 
-    logger:info(string.format("Added %d photos to collection: %s", addedCount, args.collection_name))
+    Log.info(string.format("Added %d photos to collection: %s", addedCount, args.collection_name))
 
     return {
         success = true,

--- a/plugin/LightroomMCP.lrplugin/HandlerDevelop.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerDevelop.lua
@@ -1,9 +1,7 @@
 local LrApplication = import 'LrApplication'
-local LrLogger = import 'LrLogger'
 
 local PhotoLookup = require 'PhotoLookup'
-
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 local DevelopHandler = {}
 
@@ -168,7 +166,7 @@ function DevelopHandler.listDevelopPresets(_)
         end
     end
 
-    logger:info(string.format("Listed %d develop presets", #out))
+    Log.info(string.format("Listed %d develop presets", #out))
 
     return {
         success = true,
@@ -199,7 +197,7 @@ function DevelopHandler.applyDevelopPreset(args)
         end
     end)
 
-    logger:info(string.format("Applied preset %s to %d photos", args.preset_name, appliedCount))
+    Log.info(string.format("Applied preset %s to %d photos", args.preset_name, appliedCount))
 
     return {
         success = true,
@@ -246,7 +244,7 @@ function DevelopHandler.copyDevelopSettings(args)
         end
     end)
 
-    logger:info(string.format("Copied develop settings from %s to %d photos", args.source_id, copiedCount))
+    Log.info(string.format("Copied develop settings from %s to %d photos", args.source_id, copiedCount))
 
     return {
         success = true,
@@ -272,7 +270,7 @@ function DevelopHandler.setDevelopSettings(args)
         applied = true
     end)
 
-    logger:info(string.format("Set develop settings on photo %s", args.photo_id))
+    Log.info(string.format("Set develop settings on photo %s", args.photo_id))
 
     return {
         success = applied,

--- a/plugin/LightroomMCP.lrplugin/HandlerExport.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerExport.lua
@@ -1,12 +1,10 @@
 local LrApplication = import 'LrApplication'
 local LrExportSession = import 'LrExportSession'
-local LrLogger = import 'LrLogger'
 local LrFileUtils = import 'LrFileUtils'
 local LrPathUtils = import 'LrPathUtils'
 
 local PhotoLookup = require 'PhotoLookup'
-
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 local ExportHandler = {}
 
@@ -84,7 +82,7 @@ function ExportHandler.exportPhotos(args)
     exportSession:doExportOnCurrentTask()
     local exportedCount = #photosToExport
 
-    logger:info(string.format("Exported %d photos to: %s", exportedCount, args.destination))
+    Log.info(string.format("Exported %d photos to: %s", exportedCount, args.destination))
 
     return {
         success = true,

--- a/plugin/LightroomMCP.lrplugin/HandlerImport.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerImport.lua
@@ -1,9 +1,8 @@
 local LrApplication = import 'LrApplication'
 local LrTasks = import 'LrTasks'
-local LrLogger = import 'LrLogger'
 local LrFileUtils = import 'LrFileUtils'
 
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 local ImportHandler = {}
 
@@ -77,15 +76,15 @@ function ImportHandler.importPhotos(args)
 
             if targetCollection then
                 targetCollection:addPhotos(addedPhotos)
-                logger:info(string.format("Added %d imported photos to collection: %s",
+                Log.info(string.format("Added %d imported photos to collection: %s",
                     #addedPhotos, args.collection_name))
             else
-                logger:warn("Collection not found: " .. args.collection_name)
+                Log.warn("Collection not found: " .. args.collection_name)
             end
         end)
     end
 
-    logger:info(string.format("Imported %d photos from: %s", importedCount, args.source_path))
+    Log.info(string.format("Imported %d photos from: %s", importedCount, args.source_path))
 
     return {
         success = true,

--- a/plugin/LightroomMCP.lrplugin/HandlerMetadata.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerMetadata.lua
@@ -1,9 +1,7 @@
 local LrApplication = import 'LrApplication'
-local LrLogger = import 'LrLogger'
 
 local PhotoLookup = require 'PhotoLookup'
-
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 local MetadataHandler = {}
 
@@ -68,7 +66,7 @@ function MetadataHandler.getPhotoMetadata(args)
         }
     end)
 
-    logger:info("Retrieved metadata for photo: " .. args.photo_id)
+    Log.info("Retrieved metadata for photo: " .. args.photo_id)
 
     return photoData
 end

--- a/plugin/LightroomMCP.lrplugin/HandlerOrganization.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerOrganization.lua
@@ -1,9 +1,7 @@
 local LrApplication = import 'LrApplication'
-local LrLogger = import 'LrLogger'
 
 local PhotoLookup = require 'PhotoLookup'
-
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 local OrganizationHandler = {}
 local MAX_KEYWORDS_PER_REQUEST = 1000
@@ -73,7 +71,7 @@ function OrganizationHandler.setKeywords(args)
         end
     end)
 
-    logger:info(string.format("Updated keywords for %d photos", updatedCount))
+    Log.info(string.format("Updated keywords for %d photos", updatedCount))
 
     return {
         success = true,
@@ -112,7 +110,7 @@ function OrganizationHandler.setRating(args)
         end
     end)
 
-    logger:info(string.format("Set rating to %d for %d photos", args.rating, updatedCount))
+    Log.info(string.format("Set rating to %d for %d photos", args.rating, updatedCount))
 
     return {
         success = true,

--- a/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
@@ -1,7 +1,6 @@
 local LrApplication = import 'LrApplication'
-local LrLogger = import 'LrLogger'
 
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 local SearchHandler = {}
 
@@ -59,23 +58,31 @@ function SearchHandler.searchPhotos(args)
     local offset = tonumber(args.offset) or 0
     if offset < 0 then offset = 0 end
 
-    local total = 0
+    -- Run the catalog query OUTSIDE withReadAccessDo. findPhotos() runs an
+    -- async catalog search that yields; called from inside the read gate on
+    -- Windows it deadlocks -- the task never returns and never releases the
+    -- gate, wedging the whole bridge until the 30s server timeout (issue #124,
+    -- same root cause as #134's getTargetPhotos). Only the per-photo metadata
+    -- reads need the gate. getAllPhotos() (no-filter path) is a non-yielding
+    -- enumeration, but is hoisted out too for a single, consistent structure.
+    Log.info(string.format("searchPhotos: querying (hasFilters=%s)", tostring(hasFilters)))
+    -- Unrated photos have nil rating; rating>=0 excludes them, so getAllPhotos()
+    -- must be used when no filters are specified.
+    local matches = hasFilters
+        and catalog:findPhotos{ searchDesc = searchDesc }
+        or catalog:getAllPhotos()
 
+    local total = #matches
+    Log.info(string.format("searchPhotos: query returned %d", total))
+
+    local last = math.min(offset + limit, total)
     catalog:withReadAccessDo(function()
-        -- Unrated photos have nil rating; rating>=0 excludes them, so getAllPhotos()
-        -- must be used when no filters are specified.
-        local matches = hasFilters
-            and catalog:findPhotos{ searchDesc = searchDesc }
-            or catalog:getAllPhotos()
-
-        total = #matches
-        local last = math.min(offset + limit, total)
         for i = offset + 1, last do
             table.insert(results, buildResult(matches[i]))
         end
     end)
 
-    logger:info(string.format("Search matched %d photos, returning %d (offset=%d, limit=%d)",
+    Log.info(string.format("Search matched %d photos, returning %d (offset=%d, limit=%d)",
         total, #results, offset, limit))
 
     local response = {

--- a/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSearch.lua
@@ -53,9 +53,12 @@ function SearchHandler.searchPhotos(args)
     local searchDesc = buildSearchDesc(args)
     local hasFilters = #searchDesc > 0
 
-    local limit = tonumber(args.limit) or 100
+    -- floor: the tool schema permits any number, and a fractional offset would
+    -- make the page loop index matches[i] with a non-integer key (always nil)
+    -- and crash buildResult(nil).
+    local limit = math.floor(tonumber(args.limit) or 100)
     if limit < 0 then limit = 0 end
-    local offset = tonumber(args.offset) or 0
+    local offset = math.floor(tonumber(args.offset) or 0)
     if offset < 0 then offset = 0 end
 
     -- Run the catalog query OUTSIDE withReadAccessDo. findPhotos() runs an
@@ -68,9 +71,9 @@ function SearchHandler.searchPhotos(args)
     Log.info(string.format("searchPhotos: querying (hasFilters=%s)", tostring(hasFilters)))
     -- Unrated photos have nil rating; rating>=0 excludes them, so getAllPhotos()
     -- must be used when no filters are specified.
-    local matches = hasFilters
+    local matches = (hasFilters
         and catalog:findPhotos{ searchDesc = searchDesc }
-        or catalog:getAllPhotos()
+        or catalog:getAllPhotos()) or {}
 
     local total = #matches
     Log.info(string.format("searchPhotos: query returned %d", total))

--- a/plugin/LightroomMCP.lrplugin/HandlerSelection.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSelection.lua
@@ -18,9 +18,12 @@ function SelectionHandler.getSelectedPhotos(args)
     args = args or {}
     local catalog = LrApplication.activeCatalog()
 
-    local limit = tonumber(args.limit) or 100
+    -- floor: the tool schema permits any number, and a fractional offset would
+    -- make the page loop index matches[i] with a non-integer key (always nil)
+    -- and crash buildResult(nil).
+    local limit = math.floor(tonumber(args.limit) or 100)
     if limit < 0 then limit = 0 end
-    local offset = tonumber(args.offset) or 0
+    local offset = math.floor(tonumber(args.offset) or 0)
     if offset < 0 then offset = 0 end
 
     -- Acquire the target set OUTSIDE withReadAccessDo. getTargetPhotos() reads

--- a/plugin/LightroomMCP.lrplugin/HandlerSelection.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerSelection.lua
@@ -1,7 +1,6 @@
 local LrApplication = import 'LrApplication'
-local LrLogger = import 'LrLogger'
 
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 local SelectionHandler = {}
 
@@ -24,20 +23,28 @@ function SelectionHandler.getSelectedPhotos(args)
     local offset = tonumber(args.offset) or 0
     if offset < 0 then offset = 0 end
 
-    local results = {}
-    local total = 0
+    -- Acquire the target set OUTSIDE withReadAccessDo. getTargetPhotos() reads
+    -- the live view selection, which yields to the UI thread; called from
+    -- inside the read gate on Windows it deadlocks -- the task never returns
+    -- and never releases the gate, so the whole bridge wedges until the 30s
+    -- server timeout (issues #134, #124). Only the per-photo metadata reads
+    -- need the gate; getTargetPhotos() does not. This mirrors get_photo_metadata,
+    -- which works because it only does a non-yielding getAllPhotos() pass.
+    Log.info("getSelectedPhotos: requesting target photos")
+    local matches = catalog:getTargetPhotos() or {}
+    local total = #matches
+    Log.info(string.format("getSelectedPhotos: getTargetPhotos returned %d", total))
 
+    local last = math.min(offset + limit, total)
+    local results = {}
     catalog:withReadAccessDo(function()
-        local matches = catalog:getTargetPhotos() or {}
-        total = #matches
-        local last = math.min(offset + limit, total)
         for i = offset + 1, last do
             table.insert(results, buildResult(matches[i]))
         end
     end)
 
-    logger:info(string.format("getTargetPhotos returned %d, paged %d (offset=%d, limit=%d)",
-        total, #results, offset, limit))
+    Log.info(string.format("getSelectedPhotos: returning %d (offset=%d, limit=%d)",
+        #results, offset, limit))
 
     return {
         count = total,

--- a/plugin/LightroomMCP.lrplugin/Log.lua
+++ b/plugin/LightroomMCP.lrplugin/Log.lua
@@ -1,0 +1,73 @@
+-- Reliable file logging for the plugin.
+--
+-- `LrLogger:enable("logfile")` alone proved unreliable on Windows (issue #134):
+-- its target directory `~/Documents/LrClassicLogs` is not created by us, and on
+-- Windows `Documents` is frequently redirected (OneDrive), so the file lands
+-- somewhere the user cannot find -- or nowhere. We therefore ALSO write our own
+-- copy via io.open to an OS-resolved path we control, create the directory
+-- ourselves, and expose the resolved absolute path so the Plug-in Manager can
+-- show exactly where logs go. The LrLogger channel is kept as a secondary sink.
+--
+-- pcall around `import` keeps this module loadable under the busted specs, whose
+-- mock `import` only stubs the handful of namespaces each spec needs; a missing
+-- LrPathUtils/LrFileUtils there simply disables the file sink (no stray writes).
+local function tryImport(name)
+    local ok, mod = pcall(import, name)
+    if ok then return mod end
+    return nil
+end
+
+local LrLogger = tryImport('LrLogger')
+local LrPathUtils = tryImport('LrPathUtils')
+local LrFileUtils = tryImport('LrFileUtils')
+
+local lrLogger = LrLogger and LrLogger('LightroomMCP') or nil
+if lrLogger then lrLogger:enable("logfile") end
+
+local Log = {}
+
+local resolvedPath
+local pathResolved = false
+
+-- Resolve (once) the file we own. nil if the SDK path utils are unavailable
+-- (test environment) or the OS path cannot be determined.
+local function filePath()
+    if pathResolved then return resolvedPath end
+    pathResolved = true
+    if not LrPathUtils then return nil end
+    local ok, docs = pcall(function() return LrPathUtils.getStandardFilePath("documents") end)
+    if not ok or not docs then return nil end
+    local dir = LrPathUtils.child(docs, "LrClassicLogs")
+    if LrFileUtils then
+        pcall(function() LrFileUtils.createAllDirectories(dir) end)
+    end
+    resolvedPath = LrPathUtils.child(dir, "LightroomMCP.log")
+    return resolvedPath
+end
+
+Log.filePath = filePath
+
+local function write(level, msg)
+    msg = tostring(msg)
+    if lrLogger then
+        if level == "warn" then
+            lrLogger:warn(msg)
+        elseif level == "error" then
+            lrLogger:error(msg)
+        else
+            lrLogger:info(msg)
+        end
+    end
+    local path = filePath()
+    if not path then return end
+    local fh = io.open(path, "a")
+    if not fh then return end
+    fh:write(os.date("%Y-%m-%d %H:%M:%S") .. " [" .. level .. "] " .. msg .. "\n")
+    fh:close()
+end
+
+function Log.info(msg) write("info", msg) end
+function Log.warn(msg) write("warn", msg) end
+function Log.error(msg) write("error", msg) end
+
+return Log

--- a/plugin/LightroomMCP.lrplugin/Log.lua
+++ b/plugin/LightroomMCP.lrplugin/Log.lua
@@ -47,6 +47,23 @@ end
 
 Log.filePath = filePath
 
+-- Single-file rotation cap. Without it the append-only file grows unbounded
+-- (e.g. if the server reconnect loop ever floods requests) on the same
+-- OneDrive-synced Windows path the file sink exists to reach.
+local MAX_LOG_BYTES = 5 * 1024 * 1024
+
+-- Best-effort: when the log passes the cap, move it aside to <path>.1
+-- (replacing any prior roll) and start fresh. Wrapped so a failed rotation
+-- never disrupts logging; skipped in tests where LrFileUtils is absent.
+local function rotateIfLarge(path, size)
+    if not size or size <= MAX_LOG_BYTES or not LrFileUtils then return end
+    pcall(function()
+        local rolled = path .. ".1"
+        if LrFileUtils.exists(rolled) then LrFileUtils.delete(rolled) end
+        LrFileUtils.move(path, rolled)
+    end)
+end
+
 local function write(level, msg)
     msg = tostring(msg)
     if lrLogger then
@@ -63,7 +80,9 @@ local function write(level, msg)
     local fh = io.open(path, "a")
     if not fh then return end
     fh:write(os.date("%Y-%m-%d %H:%M:%S") .. " [" .. level .. "] " .. msg .. "\n")
+    local size = fh:seek("end")
     fh:close()
+    rotateIfLarge(path, size)
 end
 
 function Log.info(msg) write("info", msg) end

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -1,5 +1,4 @@
 local LrTasks = import 'LrTasks'
-local LrLogger = import 'LrLogger'
 local LrDialogs = import 'LrDialogs'
 local LrFunctionContext = import 'LrFunctionContext'
 local LrSocket = import 'LrSocket'
@@ -18,9 +17,7 @@ local HandlerImport = require 'HandlerImport'
 local HandlerExport = require 'HandlerExport'
 local HandlerSelection = require 'HandlerSelection'
 local HandlerDevelop = require 'HandlerDevelop'
-
-local logger = LrLogger('LightroomMCP')
-logger:enable("logfile")
+local Log = require 'Log'
 
 local DEFAULT_REQUEST_PORT = 58763
 local DEFAULT_RESPONSE_PORT = 58764
@@ -85,7 +82,7 @@ local function addLog(msg)
     if #pluginState.log > 100 then
         table.remove(pluginState.log, 1)
     end
-    logger:info(msg)
+    Log.info(msg)
 end
 
 local function generateToken()
@@ -512,6 +509,7 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
     statusText = statusText .. "Requests processed: " .. pluginState.requestsProcessed .. "\n"
     statusText = statusText .. "Request port: " .. activeRequest .. " (mode=receive)\n"
     statusText = statusText .. "Response port: " .. activeResponse .. " (mode=send)\n"
+    statusText = statusText .. "Log file: " .. (Log.filePath() or "(unavailable)") .. "\n"
     statusText = statusText .. "\nRecent logs:\n"
     local startIdx = math.max(1, #pluginState.log - 15)
     for i = startIdx, #pluginState.log do
@@ -579,6 +577,7 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
                             "Response socket connected: " .. tostring(pluginState.sendConnected),
                             "Last event: " .. (pluginState.lastEvent or "Never"),
                             "Requests processed: " .. pluginState.requestsProcessed,
+                            "Log file: " .. (Log.filePath() or "(unavailable)"),
                             "",
                             "Recent logs:",
                         }

--- a/plugin/LightroomMCP.lrplugin/PluginInit.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInit.lua
@@ -1,11 +1,9 @@
 local LrPrefs = import 'LrPrefs'
 local LrTasks = import 'LrTasks'
 local LrFunctionContext = import 'LrFunctionContext'
-local LrLogger = import 'LrLogger'
 
 local PluginInfoProvider = require 'PluginInfoProvider'
-
-local logger = LrLogger('LightroomMCP')
+local Log = require 'Log'
 
 -- LrInitPlugin runs on plugin load AND on "Reload Plug-in", but NOT when
 -- Lightroom merely renders the Plug-in Manager panel. On reload a prior
@@ -41,7 +39,10 @@ if autoStart then
         -- failure #128 was about. Surface it instead.
         local ok, err = LrTasks.pcall(PluginInfoProvider.startServer)
         if not ok then
-            logger:error("Auto-start failed: " .. tostring(err))
+            -- Route through Log (not raw LrLogger) so this lands in the
+            -- OS-resolved file sink the user is told to check; the #128
+            -- "server died with nothing in the log" failure mode lived here.
+            Log.error("Auto-start failed: " .. tostring(err))
         end
     end)
 end

--- a/plugin/spec/HandlerSearch_spec.lua
+++ b/plugin/spec/HandlerSearch_spec.lua
@@ -54,6 +54,16 @@ describe("HandlerSearch.searchPhotos", function()
         assert.are.same({}, result.photos)
         assert.is_false(result.has_more)
     end)
+
+    it("runs findPhotos OUTSIDE the read-access gate (#124 deadlock guard)", function()
+        Handler.searchPhotos({ filename = "sunset" })
+        assert.is_false(catalog.getQueriedInsideReadAccess())
+    end)
+
+    it("runs getAllPhotos OUTSIDE the read-access gate when no filters", function()
+        Handler.searchPhotos({})
+        assert.is_false(catalog.getQueriedInsideReadAccess())
+    end)
 end)
 
 describe("HandlerSearch.searchPhotos pagination", function()

--- a/plugin/spec/HandlerSelection_spec.lua
+++ b/plugin/spec/HandlerSelection_spec.lua
@@ -3,8 +3,11 @@ local helper = require 'spec_helper'
 describe("HandlerSelection.getSelectedPhotos", function()
     local Handler
 
+    local lastCatalog
+
     local function setup(opts)
         local catalog = helper.fakeCatalog(opts)
+        lastCatalog = catalog
         helper.installImport({
             LrApplication = { activeCatalog = function() return catalog end },
             LrLogger = helper.defaultLrLogger(),
@@ -87,5 +90,12 @@ describe("HandlerSelection.getSelectedPhotos", function()
         assert.are.equal(0, r.count)
         assert.are.same({}, r.photos)
         assert.is_false(r.has_more)
+    end)
+
+    it("calls getTargetPhotos OUTSIDE the read-access gate (#134 deadlock guard)", function()
+        local p1 = helper.fakePhoto({ id = "1", path = "/a.jpg", fileName = "a.jpg", rating = 5 })
+        setup({ photos = { p1 }, targetPhotos = { p1 } })
+        Handler.getSelectedPhotos({})
+        assert.is_false(lastCatalog.getQueriedInsideReadAccess())
     end)
 end)

--- a/plugin/spec/PluginInit_spec.lua
+++ b/plugin/spec/PluginInit_spec.lua
@@ -45,17 +45,17 @@ local function loadInit(opts)
                 fn()
             end,
         },
-        LrLogger = setmetatable({}, {
-            __call = function()
-                return {
-                    info = function() end,
-                    warn = function() end,
-                    error = function(_, msg) observed.loggedError = msg end,
-                    enable = function() end,
-                }
-            end,
-        }),
     })
+
+    -- PluginInit now routes logging through the Log module so the auto-start
+    -- failure lands in the OS-resolved file sink, not the unreliable LrLogger
+    -- channel (issue #128). Stub Log to observe what it would log.
+    package.loaded.Log = {
+        info = function() end,
+        warn = function() end,
+        error = function(msg) observed.loggedError = msg end,
+        filePath = function() return nil end,
+    }
 
     package.loaded.PluginInit = nil
     require 'PluginInit'

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -97,6 +97,15 @@ function M.fakeCatalog(opts)
     local createdKeywords = {}
     local readAccessCount = 0
     local writeAccessCount = 0
+    -- Tracks whether a catalog query (getTargetPhotos/findPhotos/getAllPhotos)
+    -- was invoked while a withReadAccessDo gate was open. The Windows deadlock
+    -- (#134/#124) is exactly that nesting, so handlers must keep their query
+    -- OUTSIDE the gate; specs assert getQueriedInsideReadAccess() == false.
+    local insideReadAccess = false
+    local queriedInsideReadAccess = false
+    local function markQuery()
+        if insideReadAccess then queriedInsideReadAccess = true end
+    end
 
     local function photoMatches(photo, criterion)
         local crit = criterion.criteria
@@ -132,9 +141,10 @@ function M.fakeCatalog(opts)
     end
 
     return {
-        getAllPhotos = function() return photos end,
-        getTargetPhotos = function() return opts.targetPhotos or photos end,
+        getAllPhotos = function() markQuery() return photos end,
+        getTargetPhotos = function() markQuery() return opts.targetPhotos or photos end,
         findPhotos = function(_, opts)
+            markQuery()
             local desc = opts and opts.searchDesc or {}
             local out = {}
             for _, photo in ipairs(photos) do
@@ -153,8 +163,12 @@ function M.fakeCatalog(opts)
         getChildCollectionSets = function() return collectionSets end,
         withReadAccessDo = function(_, fn)
             readAccessCount = readAccessCount + 1
-            fn()
+            insideReadAccess = true
+            local ok, err = pcall(fn)
+            insideReadAccess = false
+            if not ok then error(err, 0) end
         end,
+        getQueriedInsideReadAccess = function() return queriedInsideReadAccess end,
         withWriteAccessDo = function(_, _, fn)
             writeAccessCount = writeAccessCount + 1
             fn()


### PR DESCRIPTION
## Motivation

`get_selected_photos` and `search_photos` always time out (30s) on Windows (#134, #124). Both acquire their photo set by calling a catalog query — `getTargetPhotos()` / `findPhotos()` — **inside** `withReadAccessDo`. On Windows those calls yield to the UI thread while the read gate is held, deadlocking the catalog: the task never returns and never releases the gate, so every later catalog op also hangs until the timeout (the "blocks every other tool" symptom in #124). The working handlers (`list_collections`, `get_photo_metadata`) only run non-yielding enumerations inside the gate, which is why they were fine.

The bug was hard to diagnose because no plugin log file appeared. `LrLogger:enable("logfile")` targets `~/Documents/LrClassicLogs`, which on Windows is frequently OneDrive-redirected and not auto-created, so the file landed where the user could not find it — or nowhere.

> Changelog: fix(plugin): run photo queries outside read gate

## Implementation information

- Hoist `getTargetPhotos()` / `findPhotos()` / `getAllPhotos()` out of `withReadAccessDo` in `HandlerSelection` and `HandlerSearch`; only the per-photo metadata reads stay inside the gate (same shape as the working `get_photo_metadata`).
- New `Log.lua`: writes the log file directly via `io.open` to an OS-resolved path (`LrPathUtils.getStandardFilePath("documents")/LrClassicLogs/LightroomMCP.log`, OneDrive-aware), auto-creates the directory, and mirrors to `LrLogger`. All handlers + the dispatcher route through it.
- Plug-in Manager status + Show Status now show the resolved **Log file:** path, so the location is never a mystery.
- Added granular trace logs in both handlers.
- Tests: `spec_helper` now tracks whether a query ran inside the read gate; new specs assert both handlers query outside it.

Verification: `selene` clean, 91/91 busted specs, 138/138 server tests.

Note: the deadlock is Windows-specific (LR threading differs by platform); these tools already worked on macOS, so the macOS-side change is a no-op there. The fix is principled and covered by regression specs.

## Supporting documentation

Closes #134
Closes #124