### PR TITLE
fix(plugin): import without isDirectory

### DIFF
--- a/plugin/LightroomMCP.lrplugin/HandlerImport.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerImport.lua
@@ -11,7 +11,12 @@ function ImportHandler.importPhotos(args)
         error("source_path is required")
     end
 
-    if not LrFileUtils.exists(args.source_path) then
+    -- LrFileUtils.exists returns 'file' / 'directory' / false. Use it for the
+    -- directory check too: LrFileUtils.isDirectory is absent on some Lightroom
+    -- Classic runtimes (nil there, e.g. 15.3.1 -- issue #129), whereas exists
+    -- is stable across supported versions.
+    local sourceKind = LrFileUtils.exists(args.source_path)
+    if not sourceKind then
         error("Source path does not exist: " .. args.source_path)
     end
 
@@ -21,7 +26,7 @@ function ImportHandler.importPhotos(args)
     -- Enumerate source files OUTSIDE any catalog lock; the filesystem walk
     -- needs no catalog access.
     local photosToImport = {}
-    if LrFileUtils.isDirectory(args.source_path) then
+    if sourceKind == 'directory' then
         -- Import all photos from directory
         for file in LrFileUtils.files(args.source_path) do
             local ext = LrFileUtils.extension(file):lower()

--- a/plugin/spec/HandlerImport_spec.lua
+++ b/plugin/spec/HandlerImport_spec.lua
@@ -1,9 +1,15 @@
 local helper = require 'spec_helper'
 
+-- Mirrors the real SDK: LrFileUtils.exists returns 'file' / 'directory' / false,
+-- and LrFileUtils.isDirectory is intentionally absent (nil on some Lightroom
+-- Classic runtimes -- issue #129).
 local function fakeFileUtils(opts)
     return {
-        exists = function(p) return opts.exists and opts.exists[p] end,
-        isDirectory = function(p) return opts.directories and opts.directories[p] end,
+        exists = function(p)
+            if opts.directories and opts.directories[p] then return 'directory' end
+            if opts.exists and opts.exists[p] then return 'file' end
+            return false
+        end,
         files = function(_)
             local i = 0
             local list = opts.dirContents or {}


### PR DESCRIPTION
## Motivation

Closes #129. `import_photos` crashes on Lightroom Classic 15.3.1 with `attempt to call field 'isDirectory' (a nil value)`. `LrFileUtils.isDirectory` is absent on some LrClassic runtimes, so any import (even of an existing single file) fails before reaching the catalog.

> Changelog: fix(plugin): import without LrFileUtils.isDirectory

## Implementation information

- `HandlerImport.lua`: drop `LrFileUtils.isDirectory`. Capture `LrFileUtils.exists(source_path)` once — it returns `'file'` / `'directory'` / `false` and is stable across supported versions — and branch on `== 'directory'` for the directory walk. The same call still serves the existence check.
- `HandlerImport_spec.lua`: the old fixture supplied an `isDirectory` the real SDK lacks, masking the bug. Fixture now omits `isDirectory` and makes `exists` return `'directory'`/`'file'`/`false` like the SDK.

## Supporting documentation

`mise run lua:test` (91 passing) and `mise run lua:lint` (0 warnings) both green.