### PR TITLE
feat(plugin): expand get_photo_metadata fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If you'd rather drop the plugin in by hand:
 | --- | --- |
 | `search_photos` | Search by filename / keywords / rating / date range. |
 | `get_selected_photos` | Photos selected in Lightroom (or filmstrip). |
-| `get_photo_metadata` | EXIF + develop settings for one photo. |
+| `get_photo_metadata` | EXIF, GPS, IPTC location, copyright + develop settings for one photo. |
 | `list_collections` | All collections and collection sets. |
 | `create_collection` | New collection (optional parent set). |
 | `add_to_collection` | Add photos to a named collection. |

--- a/plugin/LightroomMCP.lrplugin/HandlerMetadata.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerMetadata.lua
@@ -5,6 +5,16 @@ local Log = require 'Log'
 
 local MetadataHandler = {}
 
+-- Return the group only when it carries at least one value, so empty IPTC
+-- sections are omitted from the response (consistent with the gps group)
+-- instead of surfacing a table full of empty strings.
+local function nonEmptyGroup(fields)
+    for _, v in pairs(fields) do
+        if v ~= nil and v ~= "" then return fields end
+    end
+    return nil
+end
+
 function MetadataHandler.getPhotoMetadata(args)
     if not args.photo_id then
         error("photo_id is required")
@@ -32,6 +42,17 @@ function MetadataHandler.getPhotoMetadata(args)
         -- Get develop settings
         local developSettings = photo:getDevelopSettings()
 
+        -- GPS is a raw {latitude, longitude} table; omit the group when absent.
+        local gps = photo:getRawMetadata('gps')
+        local gpsData = nil
+        if gps then
+            gpsData = {
+                latitude = gps.latitude,
+                longitude = gps.longitude,
+                altitude = photo:getRawMetadata('gpsAltitude'),
+            }
+        end
+
         photoData = {
             id = photo.localIdentifier,
             path = photo:getRawMetadata('path'),
@@ -40,26 +61,59 @@ function MetadataHandler.getPhotoMetadata(args)
             colorLabel = photo:getRawMetadata('colorNameForLabel'),
             pickStatus = photo:getRawMetadata('pickStatus'),
             keywords = keywords,
+            -- Title / caption / headline (IPTC content description).
+            title = photo:getFormattedMetadata('title'),
+            caption = photo:getFormattedMetadata('caption'),
+            headline = photo:getFormattedMetadata('headline'),
+            -- EXIF capture data.
             dateTimeOriginal = photo:getFormattedMetadata('dateTimeOriginal'),
+            dateTimeDigitized = photo:getFormattedMetadata('dateTimeDigitized'),
             cameraMake = photo:getFormattedMetadata('cameraMake'),
             cameraModel = photo:getFormattedMetadata('cameraModel'),
+            cameraSerialNumber = photo:getFormattedMetadata('cameraSerialNumber'),
             lens = photo:getFormattedMetadata('lens'),
             isoSpeedRating = photo:getFormattedMetadata('isoSpeedRating'),
             focalLength = photo:getFormattedMetadata('focalLength'),
+            focalLength35mm = photo:getFormattedMetadata('focalLength35mm'),
             aperture = photo:getFormattedMetadata('aperture'),
             shutterSpeed = photo:getFormattedMetadata('shutterSpeed'),
+            exposureBias = photo:getFormattedMetadata('exposureBias'),
+            exposureProgram = photo:getFormattedMetadata('exposureProgram'),
+            meteringMode = photo:getFormattedMetadata('meteringMode'),
+            flash = photo:getFormattedMetadata('flash'),
             dimensions = photo:getFormattedMetadata('dimensions'),
             fileSize = photo:getFormattedMetadata('fileSize'),
             fileFormat = photo:getRawMetadata('fileFormat'),
+            artist = photo:getFormattedMetadata('artist'),
+            software = photo:getFormattedMetadata('software'),
+            gps = gpsData,
+            -- IPTC location ("Sublocation" is the SDK `location` field).
+            location = nonEmptyGroup({
+                sublocation = photo:getFormattedMetadata('location'),
+                city = photo:getFormattedMetadata('city'),
+                stateProvince = photo:getFormattedMetadata('stateProvince'),
+                country = photo:getFormattedMetadata('country'),
+                isoCountryCode = photo:getFormattedMetadata('isoCountryCode'),
+            }),
+            copyright = nonEmptyGroup({
+                creator = photo:getFormattedMetadata('creator'),
+                notice = photo:getFormattedMetadata('copyright'),
+                status = photo:getFormattedMetadata('copyrightState'),
+                rightsUsageTerms = photo:getFormattedMetadata('rightsUsageTerms'),
+            }),
             developSettings = {
                 whiteBalance = developSettings.WhiteBalance,
+                temperature = developSettings.Temperature,
+                tint = developSettings.Tint,
                 exposure = developSettings.Exposure2012,
                 contrast = developSettings.Contrast2012,
                 highlights = developSettings.Highlights2012,
                 shadows = developSettings.Shadows2012,
                 whites = developSettings.Whites2012,
                 blacks = developSettings.Blacks2012,
+                texture = developSettings.Texture,
                 clarity = developSettings.Clarity2012,
+                dehaze = developSettings.Dehaze,
                 vibrance = developSettings.Vibrance,
                 saturation = developSettings.Saturation,
             }

--- a/plugin/LightroomMCP.lrplugin/HandlerMetadata.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerMetadata.lua
@@ -42,15 +42,16 @@ function MetadataHandler.getPhotoMetadata(args)
         -- Get develop settings
         local developSettings = photo:getDevelopSettings()
 
-        -- GPS is a raw {latitude, longitude} table; omit the group when absent.
+        -- GPS is a raw {latitude, longitude} table; omit the group when absent
+        -- or when present but carrying no coordinates.
         local gps = photo:getRawMetadata('gps')
         local gpsData = nil
         if gps then
-            gpsData = {
+            gpsData = nonEmptyGroup({
                 latitude = gps.latitude,
                 longitude = gps.longitude,
                 altitude = photo:getRawMetadata('gpsAltitude'),
-            }
+            })
         end
 
         photoData = {

--- a/plugin/spec/HandlerMetadata_spec.lua
+++ b/plugin/spec/HandlerMetadata_spec.lua
@@ -38,6 +38,60 @@ describe("HandlerMetadata.getPhotoMetadata", function()
         assert.are.same({ "summer", "beach" }, r.keywords)
     end)
 
+    it("exposes IPTC location, GPS, and copyright metadata", function()
+        local photo = helper.fakePhoto({
+            id = "7",
+            path = "/p/street.jpg",
+            fileName = "street.jpg",
+            title = "Main Street",
+            caption = "Downtown at dusk",
+            headline = "Evening commute",
+            location = "5th Avenue",
+            city = "New York",
+            stateProvince = "NY",
+            country = "USA",
+            isoCountryCode = "US",
+            gps = { latitude = 40.7128, longitude = -74.006 },
+            gpsAltitude = 10.5,
+            creator = "Jane Doe",
+            copyright = "© Jane Doe",
+            copyrightState = "Copyrighted",
+            rightsUsageTerms = "All rights reserved",
+        })
+        local _, Handler = setup({ photo })
+
+        local r = Handler.getPhotoMetadata({ photo_id = "7" })
+
+        assert.are.equal("Main Street", r.title)
+        assert.are.equal("Downtown at dusk", r.caption)
+        assert.are.equal("5th Avenue", r.location.sublocation)
+        assert.are.equal("New York", r.location.city)
+        assert.are.equal("US", r.location.isoCountryCode)
+        assert.are.equal(40.7128, r.gps.latitude)
+        assert.are.equal(-74.006, r.gps.longitude)
+        assert.are.equal(10.5, r.gps.altitude)
+        assert.are.equal("Jane Doe", r.copyright.creator)
+        assert.are.equal("Copyrighted", r.copyright.status)
+    end)
+
+    it("omits gps, location, and copyright groups when empty", function()
+        local photo = helper.fakePhoto({ id = "8", path = "/p/no-gps.jpg", fileName = "no-gps.jpg" })
+        local _, Handler = setup({ photo })
+
+        local r = Handler.getPhotoMetadata({ photo_id = "8" })
+        assert.is_nil(r.gps)
+        assert.is_nil(r.location)
+        assert.is_nil(r.copyright)
+    end)
+
+    it("reads only valid SDK metadata keys (mock rejects typos)", function()
+        -- Guards against a typo'd key that would throw inside withReadAccessDo
+        -- in real Lightroom. The mock errors on keys absent from the SDK allowlist.
+        local photo = helper.fakePhoto({ id = "9", fileName = "f.jpg" })
+        assert.has_error(function() photo:getFormattedMetadata("copyrightStatus") end)
+        assert.has_no.errors(function() photo:getFormattedMetadata("copyrightState") end)
+    end)
+
     it("falls back to lookup by path when local id misses", function()
         local photo = helper.fakePhoto({
             id = "99",

--- a/plugin/spec/HandlerMetadata_spec.lua
+++ b/plugin/spec/HandlerMetadata_spec.lua
@@ -84,6 +84,14 @@ describe("HandlerMetadata.getPhotoMetadata", function()
         assert.is_nil(r.copyright)
     end)
 
+    it("omits the gps group when the raw table carries no coordinates", function()
+        local photo = helper.fakePhoto({ id = "10", fileName = "empty-gps.jpg", gps = {} })
+        local _, Handler = setup({ photo })
+
+        local r = Handler.getPhotoMetadata({ photo_id = "10" })
+        assert.is_nil(r.gps)
+    end)
+
     it("reads only valid SDK metadata keys (mock rejects typos)", function()
         -- Guards against a typo'd key that would throw inside withReadAccessDo
         -- in real Lightroom. The mock errors on keys absent from the SDK allowlist.

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -42,7 +42,7 @@ end
 
 -- Valid Lightroom SDK metadata keys. The real getRawMetadata/getFormattedMetadata
 -- THROW on an unsupported key, taking down the enclosing withReadAccessDo. The
--- unvalidating mock used to return a value for any key, so a typo'd/invalid key
+-- non-validating mock used to return a value for any key, so a typo'd/invalid key
 -- (e.g. `copyrightStatus` for `copyrightState`) shipped green. Validate against
 -- this allowlist so specs catch it. Add genuinely-new SDK keys here.
 local VALID_METADATA_KEYS = {}

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -40,13 +40,48 @@ function M.defaultLrLogger()
     })
 end
 
+-- Valid Lightroom SDK metadata keys. The real getRawMetadata/getFormattedMetadata
+-- THROW on an unsupported key, taking down the enclosing withReadAccessDo. The
+-- unvalidating mock used to return a value for any key, so a typo'd/invalid key
+-- (e.g. `copyrightStatus` for `copyrightState`) shipped green. Validate against
+-- this allowlist so specs catch it. Add genuinely-new SDK keys here.
+local VALID_METADATA_KEYS = {}
+for _, key in ipairs({
+    -- File / catalog
+    "fileName", "fileSize", "fileFormat", "path", "dimensions",
+    "rating", "colorNameForLabel", "pickStatus", "keywords",
+    -- EXIF
+    "dateTimeOriginal", "dateTimeDigitized", "cameraMake", "cameraModel",
+    "cameraSerialNumber", "lens", "isoSpeedRating", "focalLength",
+    "focalLength35mm", "aperture", "shutterSpeed", "exposureBias",
+    "exposureProgram", "meteringMode", "flash", "artist", "software",
+    "gps", "gpsAltitude",
+    -- IPTC content / location / rights
+    "title", "caption", "headline", "location", "city", "stateProvince",
+    "country", "isoCountryCode", "creator", "copyright", "copyrightState",
+    "rightsUsageTerms",
+}) do
+    VALID_METADATA_KEYS[key] = true
+end
+M.VALID_METADATA_KEYS = VALID_METADATA_KEYS
+
+local function readMetadata(meta, key)
+    -- `__`-prefixed keys are test-internal sentinels (e.g. __appliedSettings)
+    -- that specs read back to assert what a handler wrote; never SDK keys.
+    if key:sub(1, 2) ~= "__" and not VALID_METADATA_KEYS[key] then
+        error("unsupported metadata key '" .. tostring(key)
+            .. "' (add it to spec_helper VALID_METADATA_KEYS if it is a real SDK key)", 2)
+    end
+    return meta[key]
+end
+
 -- Build a fake photo with the given metadata table.
 -- meta keys correspond to keys passed to getRawMetadata / getFormattedMetadata / localIdentifier.
 function M.fakePhoto(meta)
     return {
         localIdentifier = meta.localIdentifier or meta.id or "photo-id",
-        getRawMetadata = function(_, key) return meta[key] end,
-        getFormattedMetadata = function(_, key) return meta[key] end,
+        getRawMetadata = function(_, key) return readMetadata(meta, key) end,
+        getFormattedMetadata = function(_, key) return readMetadata(meta, key) end,
         getDevelopSettings = function() return meta.developSettings or {} end,
         addKeyword = function(_, kw)
             meta.__addedKeywords = meta.__addedKeywords or {}

--- a/server/src/tool-contracts.ts
+++ b/server/src/tool-contracts.ts
@@ -129,7 +129,8 @@ export const TOOL_CONTRACTS: ToolContract[] = [
   {
     name: "get_photo_metadata",
     luaHandler: "HandlerMetadata.getPhotoMetadata",
-    description: "Get detailed metadata for a specific photo",
+    description:
+      "Get detailed metadata for a specific photo: EXIF, title/caption, GPS coordinates, IPTC location (sublocation/city/state/country), copyright, and develop settings",
     inputSchema: {
       type: "object",
       additionalProperties: false,

--- a/server/src/tool-contracts.ts
+++ b/server/src/tool-contracts.ts
@@ -130,7 +130,7 @@ export const TOOL_CONTRACTS: ToolContract[] = [
     name: "get_photo_metadata",
     luaHandler: "HandlerMetadata.getPhotoMetadata",
     description:
-      "Get detailed metadata for a specific photo: EXIF, title/caption, GPS coordinates, IPTC location (sublocation/city/state/country), copyright, and develop settings",
+      "Get detailed metadata for a specific photo: EXIF, title/caption/headline, GPS (latitude/longitude/altitude), IPTC location (sublocation/city/stateProvince/country/isoCountryCode), copyright, and develop settings",
     inputSchema: {
       type: "object",
       additionalProperties: false,


### PR DESCRIPTION
## Motivation

`get_photo_metadata` only returned a small, hand-picked subset of fields, so
data visible in Lightroom — notably the IPTC **Sublocation** and the rest of
the GPS/location section — was unreachable. Closes #131.

There is no Lightroom limitation here: `getFormattedMetadata` /
`getRawMetadata` expose far more than was being read. "Sublocation" is the SDK
`location` key, which simply wasn't requested.

> Changelog: feat(plugin): expand get_photo_metadata fields

## Implementation information

`HandlerMetadata.getPhotoMetadata` now also returns:

- **IPTC location** (`location` group): `sublocation`, `city`, `stateProvince`,
  `country`, `isoCountryCode`
- **GPS** (`gps` group): `latitude`, `longitude`, `altitude`
- **Copyright** (`copyright` group): `creator`, `notice`, `status`,
  `rightsUsageTerms`
- **Content**: `title`, `caption`, `headline`
- **More EXIF**: `dateTimeDigitized`, `cameraSerialNumber`, `focalLength35mm`,
  `exposureBias`, `exposureProgram`, `meteringMode`, `flash`, `artist`,
  `software`
- **More develop settings**: `temperature`, `tint`, `texture`, `dehaze`

Design notes:

- Only documented SDK keys are used — `getFormattedMetadata` throws on an
  unknown key, which would take down the whole `withReadAccessDo` block.
- All additions are non-yielding per-photo reads, so the read-gate stays safe
  (no #124/#134 deadlock risk).
- `gps`, `location`, and `copyright` groups are omitted when empty, instead of
  emitting tables full of empty strings.
- The busted mock now validates metadata keys against the SDK allowlist, so a
  typo'd key fails the suite instead of passing green (the old mock returned a
  value for any key).

The change was red-teamed by an adversarial review subagent: every new SDK key
was verified against the Adobe token allowlist, the GPS nil-guard / field names
and JSON object-vs-array encoding checked — verdict CLEAN. The two non-blocking
suggestions it raised (mock key validation, group-omission consistency) are
both addressed here.

## Supporting documentation

- Issue #131
- Lightroom Classic SDK `LrPhoto:getFormattedMetadata` / `getRawMetadata`
