### PR TITLE
fix(plugin): recover from stale connection after MCP server restart on Windows

### DIFF
--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -172,6 +172,19 @@ local STALE_RECONNECT_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 3
 -- PR #151: "a tool call landing in the restart window loses its response").
 local STALE_RESTART_HARD_CAP_SECONDS = STALE_RECONNECT_SECONDS + 30
 
+-- Pure decision extracted from the monitor loop so it can be unit tested
+-- without driving the full async LrTasks loop (see PluginInfoProvider_spec.lua).
+-- Returns whether to restart and, if so, a log-suffix noting whether the
+-- hard cap (not just the soft threshold) is what triggered it.
+local function shouldRestartForStaleConnection(idle, inFlightRequests, softSeconds, hardCapSeconds)
+    local inFlight = (inFlightRequests or 0) > 0
+    local pastSoft = idle > softSeconds
+    local pastHard = idle > hardCapSeconds
+    local restart = pastSoft and (not inFlight or pastHard)
+    local suffix = (inFlight and pastHard) and " [hard cap, request still in flight]" or ""
+    return restart, suffix
+end
+
 local function sendResponse(response)
     local waited = 0
     local selfHealRequested = false
@@ -500,11 +513,9 @@ local function startServer()
                 local ref = pluginState.lastRequestTime or pluginState.lastConnectedTime
                 if ref then
                     local idle = os.time() - ref
-                    local inFlight = (pluginState.inFlightRequests or 0) > 0
-                    local pastSoft = idle > STALE_RECONNECT_SECONDS
-                    local pastHard = idle > STALE_RESTART_HARD_CAP_SECONDS
-                    if pastSoft and (not inFlight or pastHard) then
-                        local suffix = (inFlight and pastHard) and " [hard cap, request still in flight]" or ""
+                    local restart, suffix = shouldRestartForStaleConnection(
+                        idle, pluginState.inFlightRequests, STALE_RECONNECT_SECONDS, STALE_RESTART_HARD_CAP_SECONDS)
+                    if restart then
                         addLog("Stale connection: " .. idle .. "s since last heartbeat, scheduling restart" .. suffix)
                         pluginState.lastRequestTime = nil
                         pluginState.lastConnectedTime = nil
@@ -579,6 +590,12 @@ local PluginInfoProvider = {
     startServer = startServer,
     stopServer = stopServer,
     resetForReload = resetForReload,
+    -- Exposed for PluginInfoProvider_spec.lua only; not used elsewhere in the plugin.
+    shouldRestartForStaleConnection = shouldRestartForStaleConnection,
+    handlePing = DISPATCH.ping,
+    HEARTBEAT_INTERVAL_SECONDS = HEARTBEAT_INTERVAL_SECONDS,
+    STALE_RECONNECT_SECONDS = STALE_RECONNECT_SECONDS,
+    STALE_RESTART_HARD_CAP_SECONDS = STALE_RESTART_HARD_CAP_SECONDS,
 }
 
 function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -47,11 +47,11 @@ end
 -- within the same Lua state. This body runs BOTH when PluginInit requires
 -- it AND every time Lightroom loads it as the InfoProvider to render the
 -- Plug-in Manager panel. A render must NOT disturb a running server, so we
--- only ever CREATE state here (when absent) — never tear it down. Teardown
+-- only ever CREATE state here (when absent) â€” never tear it down. Teardown
 -- of a stale prior instance on Reload Plug-in is handled by resetForReload,
 -- which PluginInit calls (PluginInit's LrInitPlugin runs on load/reload but
--- NOT on a plain panel render). Tearing down from this body — as earlier
--- versions did when running == true — killed the live server every time the
+-- NOT on a plain panel render). Tearing down from this body â€” as earlier
+-- versions did when running == true â€” killed the live server every time the
 -- Plug-in Manager was opened (issues #121, #137).
 if not _G.LightroomMCP_State then
     _G.LightroomMCP_State = {
@@ -64,6 +64,10 @@ if not _G.LightroomMCP_State then
         lastEvent = nil,
         log = {},
         token = nil,
+        lastRequestTime = nil,
+        lastConnectedTime = nil,
+        needsFullRestart = false,
+        freshRestart = false,
     }
 end
 
@@ -86,7 +90,7 @@ local function addLog(msg)
 end
 
 local function generateToken()
-    -- Two UUIDs (32 hex chars each after stripping dashes) → 256 bits of entropy.
+    -- Two UUIDs (32 hex chars each after stripping dashes) â†’ 256 bits of entropy.
     local u1 = LrUUID.generateUUID():gsub("-", "")
     local u2 = LrUUID.generateUUID():gsub("-", "")
     return (u1 .. u2):lower()
@@ -136,11 +140,15 @@ local DISPATCH = {
 local SEND_WAIT_SECONDS = 25
 -- After this many seconds of waiting for sendConnected, request a fresh
 -- response-side rebind. Recovers from states where the response listener
--- ended up bound-but-clientless without responseNeedsRebind being set —
+-- ended up bound-but-clientless without responseNeedsRebind being set â€”
 -- observed on Windows in issue #110, where the post-rebind onConnected
 -- fires but sendConnected is later false by the time sendResponse runs
 -- and no event sets the rebind flag again.
 local SEND_REBIND_TRIGGER_SECONDS = 5
+-- After this many idle seconds while receiveConnected is true, assume the
+-- connection is stale (Windows onClosed unreliability, issue #134) and
+-- force a requestSocket:reconnect() so the new MCP server can be accepted.
+local STALE_RECONNECT_SECONDS = 300
 
 local function sendResponse(response)
     local waited = 0
@@ -201,6 +209,7 @@ end
 -- live token.
 local function consumeMessage(message)
     pluginState.lastEvent = os.date("%H:%M:%S")
+    pluginState.lastRequestTime = os.time()  -- track for stale connection detection
 
     local parsedOk, request = pcall(function() return JSON:decode(message) end)
     if not parsedOk or type(request) ~= "table" then
@@ -283,15 +292,25 @@ local function startServer()
                 mode = "receive",
                 onConnected = function()
                     pluginState.receiveConnected = true
-                    -- New request client = new MCP session. Force a
-                    -- response-side rebind so the freshly-bound listener
-                    -- accepts THIS client's response-port TCP. LrSocket
-                    -- send-mode doesn't reliably notice client disconnect,
-                    -- so without this `sendConnected` stays true pointing
-                    -- at the prior client and :send() writes to the void.
-                    pluginState.sendConnected = false
-                    pluginState.responseNeedsRebind = true
-                    addLog("REQUEST socket connected")
+                    pluginState.lastConnectedTime = os.time()
+                    if pluginState.freshRestart then
+                        -- Sockets were fully closed and rebound by the stale-detection
+                        -- restart (issue #134 Windows workaround). The response listener
+                        -- already accepted a fresh MCP client; no stale send-side
+                        -- connection to flush. Skipping the rebind prevents the
+                        -- request->response->request cycling that delays the first
+                        -- post-restart response past the 30 s MCP timeout.
+                        pluginState.freshRestart = false
+                        addLog("REQUEST socket connected (post-restart)")
+                    else
+                        -- New request client on a live server = new MCP session. Force
+                        -- a response-side rebind: LrSocket send-mode does not reliably
+                        -- notice client disconnect on Windows, so sendConnected can stay
+                        -- true pointing at a dead socket and :send() writes to the void.
+                        pluginState.sendConnected = false
+                        pluginState.responseNeedsRebind = true
+                        addLog("REQUEST socket connected")
+                    end
                 end,
                 onMessage = function(_, message)
                     local request = consumeMessage(message)
@@ -418,6 +437,36 @@ local function startServer()
                 pluginState.responseNeedsReconnect = false
                 pluginState.responseSocket:reconnect()
             end
+            -- Full restart requested by stale detection
+            if pluginState.needsFullRestart then
+                pluginState.needsFullRestart = false
+                LrTasks.startAsyncTask(function()
+                    addLog("Restarting server (stale connection recovery)")
+                    -- stopServer() is declared after startServer() in this file
+                    -- and is not an upvalue here; inline its effect directly.
+                    pluginState.running = false
+                    LrTasks.sleep(0.5)
+                    startServer()
+                end)
+            end
+            -- Stale connection detection: Windows LrSocket does not reliably
+            -- fire onClosed when the remote MCP server process exits (issue #134).
+            -- If receiveConnected is true but no message has arrived for
+            -- STALE_RECONNECT_SECONDS, force a reconnect so the already-connected
+            -- MCP server can be properly accepted by a fresh listener.
+            if pluginState.receiveConnected then
+                local ref = pluginState.lastRequestTime or pluginState.lastConnectedTime
+                if ref then
+                    local idle = os.time() - ref
+                    if idle > STALE_RECONNECT_SECONDS then
+                        addLog("Stale connection: " .. idle .. "s idle, scheduling restart")
+                        pluginState.lastRequestTime = nil
+                        pluginState.lastConnectedTime = nil
+                        pluginState.needsFullRestart = true
+                        pluginState.freshRestart = true
+                    end
+                end
+            end
             LrTasks.sleep(0.2)
         end
 
@@ -442,7 +491,7 @@ end
 -- subsequent startServer() isn't blocked by its "Already running" guard,
 -- and signal any surviving monitor loop to exit. Reset IN PLACE (not a new
 -- table) so this module's pluginState and the old loop's closure keep
--- pointing at the same table — flipping running here is what stops it.
+-- pointing at the same table â€” flipping running here is what stops it.
 local function resetForReload()
     if not pluginState.running then return end
     addLog("Reload detected - resetting previous server instance")
@@ -471,6 +520,10 @@ local function resetForReload()
     pluginState.requestsProcessed = 0
     pluginState.requestPort = nil
     pluginState.responsePort = nil
+    pluginState.lastRequestTime = nil
+    pluginState.lastConnectedTime = nil
+    pluginState.needsFullRestart = false
+    pluginState.freshRestart = false
 end
 
 addLog("PluginInfoProvider loaded")
@@ -599,3 +652,5 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
 end
 
 return PluginInfoProvider
+
+

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -225,13 +225,15 @@ local function dispatchAction(request)
     end
 
     -- Tracked so the stale-connection monitor can defer a restart while a
-    -- real request is in flight (see STALE_RESTART_HARD_CAP_SECONDS).
+    -- real request is in flight. Held through sendResponse (not just the
+    -- handler call) so the monitor can't yank the socket while a response
+    -- is still queued waiting on sendConnected (see STALE_RESTART_HARD_CAP_SECONDS).
     pluginState.inFlightRequests = (pluginState.inFlightRequests or 0) + 1
 
     local handler = DISPATCH[action]
     if not handler then
-        pluginState.inFlightRequests = math.max(0, pluginState.inFlightRequests - 1)
         sendResponse({ id = id, error = "Unknown action: " .. tostring(action) })
+        pluginState.inFlightRequests = math.max(0, pluginState.inFlightRequests - 1)
         return
     end
 
@@ -242,13 +244,13 @@ local function dispatchAction(request)
     local execOk, resultOrErr = LrTasks.pcall(function()
         return handler(params)
     end)
-    pluginState.inFlightRequests = math.max(0, pluginState.inFlightRequests - 1)
     if execOk then
         sendResponse({ id = id, result = resultOrErr })
     else
         addLog("Handler " .. action .. " error: " .. tostring(resultOrErr))
         sendResponse({ id = id, error = tostring(resultOrErr) })
     end
+    pluginState.inFlightRequests = math.max(0, pluginState.inFlightRequests - 1)
 end
 
 -- Runs SYNCHRONOUSLY in onMessage. Every request must carry the current
@@ -343,6 +345,13 @@ local function startServer()
                 onConnected = function()
                     pluginState.receiveConnected = true
                     pluginState.lastConnectedTime = os.time()
+                    -- A stale lastRequestTime from a prior session (e.g. user
+                    -- Stop/Start after the connection sat idle >90s) must not
+                    -- leak into this connection's idle clock, or the monitor
+                    -- loop sees a huge idle value on the very first tick and
+                    -- restarts immediately. Idle now starts from
+                    -- lastConnectedTime until the first real message arrives.
+                    pluginState.lastRequestTime = nil
                     if pluginState.freshRestart then
                         -- Sockets were fully closed and rebound by the stale-detection
                         -- restart (issue #134 Windows workaround). The response listener

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -47,11 +47,11 @@ end
 -- within the same Lua state. This body runs BOTH when PluginInit requires
 -- it AND every time Lightroom loads it as the InfoProvider to render the
 -- Plug-in Manager panel. A render must NOT disturb a running server, so we
--- only ever CREATE state here (when absent) â€” never tear it down. Teardown
+-- only ever CREATE state here (when absent) — never tear it down. Teardown
 -- of a stale prior instance on Reload Plug-in is handled by resetForReload,
 -- which PluginInit calls (PluginInit's LrInitPlugin runs on load/reload but
--- NOT on a plain panel render). Tearing down from this body â€” as earlier
--- versions did when running == true â€” killed the live server every time the
+-- NOT on a plain panel render). Tearing down from this body — as earlier
+-- versions did when running == true — killed the live server every time the
 -- Plug-in Manager was opened (issues #121, #137).
 if not _G.LightroomMCP_State then
     _G.LightroomMCP_State = {
@@ -68,6 +68,7 @@ if not _G.LightroomMCP_State then
         lastConnectedTime = nil,
         needsFullRestart = false,
         freshRestart = false,
+        inFlightRequests = 0,
     }
 end
 
@@ -90,7 +91,7 @@ local function addLog(msg)
 end
 
 local function generateToken()
-    -- Two UUIDs (32 hex chars each after stripping dashes) â†’ 256 bits of entropy.
+    -- Two UUIDs (32 hex chars each after stripping dashes) → 256 bits of entropy.
     local u1 = LrUUID.generateUUID():gsub("-", "")
     local u2 = LrUUID.generateUUID():gsub("-", "")
     return (u1 .. u2):lower()
@@ -116,6 +117,14 @@ local function writeTokenFile(token)
 end
 
 local DISPATCH = {
+    -- Heartbeat no-op. The MCP server pings on this action every
+    -- HEARTBEAT_INTERVAL_SECONDS (server/src/index.ts) so the plugin can
+    -- tell a healthy-but-idle session apart from a genuinely dead one
+    -- without waiting out a long fixed timer. It travels through the same
+    -- auth + dispatch path as any other action, so consumeMessage's
+    -- lastRequestTime update (below) already treats it as liveness — no
+    -- separate heartbeat bookkeeping needed. See STALE_RECONNECT_SECONDS.
+    ping = function(_params) return { pong = true } end,
     search_photos = HandlerSearch.searchPhotos,
     list_collections = HandlerCollections.listCollections,
     create_collection = HandlerCollections.createCollection,
@@ -140,15 +149,28 @@ local DISPATCH = {
 local SEND_WAIT_SECONDS = 25
 -- After this many seconds of waiting for sendConnected, request a fresh
 -- response-side rebind. Recovers from states where the response listener
--- ended up bound-but-clientless without responseNeedsRebind being set â€”
+-- ended up bound-but-clientless without responseNeedsRebind being set —
 -- observed on Windows in issue #110, where the post-rebind onConnected
 -- fires but sendConnected is later false by the time sendResponse runs
 -- and no event sets the rebind flag again.
 local SEND_REBIND_TRIGGER_SECONDS = 5
--- After this many idle seconds while receiveConnected is true, assume the
--- connection is stale (Windows onClosed unreliability, issue #134) and
--- force a requestSocket:reconnect() so the new MCP server can be accepted.
-local STALE_RECONNECT_SECONDS = 300
+-- The MCP server pings every HEARTBEAT_INTERVAL_SECONDS (server/src/index.ts).
+-- Treat the connection as stale only after missing roughly three pings in a
+-- row, rather than the old fixed 300s idle window. This is what lets a
+-- healthy-but-quiet interactive session run indefinitely without tripping a
+-- full restart (Automaat review, PR #151: "idle and stale connections are
+-- indistinguishable") while still detecting a genuinely dead peer (Windows
+-- onClosed unreliability, issue #134) in under two minutes.
+local HEARTBEAT_INTERVAL_SECONDS = 30
+local STALE_RECONNECT_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 3
+-- If a request is in flight when the soft threshold above is hit, give it a
+-- chance to finish rather than yanking the socket out from under it — but
+-- only up to this hard cap past the soft threshold. If the peer is truly
+-- dead the in-flight request was already unrecoverable, so the hard cap
+-- guarantees we still restart instead of waiting forever on a hung handler.
+-- Bounds the blast radius of a stale-triggered restart (Automaat review,
+-- PR #151: "a tool call landing in the restart window loses its response").
+local STALE_RESTART_HARD_CAP_SECONDS = STALE_RECONNECT_SECONDS + 30
 
 local function sendResponse(response)
     local waited = 0
@@ -180,10 +202,22 @@ local function dispatchAction(request)
     local action = request.action
     local params = request.params or {}
 
-    addLog("Request id=" .. tostring(id) .. " action=" .. tostring(action))
+    -- Heartbeat pings arrive every 30s and are pure liveness noise once the
+    -- connection is healthy; skip them here so they don't dominate the
+    -- 100-line ring buffer used by the status panel and drown out real
+    -- request activity.
+    local isHeartbeat = (action == "ping")
+    if not isHeartbeat then
+        addLog("Request id=" .. tostring(id) .. " action=" .. tostring(action))
+    end
+
+    -- Tracked so the stale-connection monitor can defer a restart while a
+    -- real request is in flight (see STALE_RESTART_HARD_CAP_SECONDS).
+    pluginState.inFlightRequests = (pluginState.inFlightRequests or 0) + 1
 
     local handler = DISPATCH[action]
     if not handler then
+        pluginState.inFlightRequests = math.max(0, pluginState.inFlightRequests - 1)
         sendResponse({ id = id, error = "Unknown action: " .. tostring(action) })
         return
     end
@@ -195,6 +229,7 @@ local function dispatchAction(request)
     local execOk, resultOrErr = LrTasks.pcall(function()
         return handler(params)
     end)
+    pluginState.inFlightRequests = math.max(0, pluginState.inFlightRequests - 1)
     if execOk then
         sendResponse({ id = id, result = resultOrErr })
     else
@@ -209,7 +244,9 @@ end
 -- live token.
 local function consumeMessage(message)
     pluginState.lastEvent = os.date("%H:%M:%S")
-    pluginState.lastRequestTime = os.time()  -- track for stale connection detection
+    pluginState.lastRequestTime = os.time()  -- track for stale connection detection; a
+                                              -- heartbeat ping counts as activity same as
+                                              -- any other message.
 
     local parsedOk, request = pcall(function() return JSON:decode(message) end)
     if not parsedOk or type(request) ~= "table" then
@@ -451,15 +488,24 @@ local function startServer()
             end
             -- Stale connection detection: Windows LrSocket does not reliably
             -- fire onClosed when the remote MCP server process exits (issue #134).
-            -- If receiveConnected is true but no message has arrived for
-            -- STALE_RECONNECT_SECONDS, force a reconnect so the already-connected
-            -- MCP server can be properly accepted by a fresh listener.
+            -- The MCP server pings every HEARTBEAT_INTERVAL_SECONDS, so as long as
+            -- the connection is genuinely alive, lastRequestTime keeps advancing
+            -- even with no real tool calls in flight. If receiveConnected is true
+            -- but nothing (including a heartbeat) has arrived for
+            -- STALE_RECONNECT_SECONDS, the peer is actually gone, not just idle.
+            -- Defer past that soft threshold while a real request is in flight,
+            -- up to STALE_RESTART_HARD_CAP_SECONDS, so we don't yank the socket
+            -- out from under a response that's about to be sent.
             if pluginState.receiveConnected then
                 local ref = pluginState.lastRequestTime or pluginState.lastConnectedTime
                 if ref then
                     local idle = os.time() - ref
-                    if idle > STALE_RECONNECT_SECONDS then
-                        addLog("Stale connection: " .. idle .. "s idle, scheduling restart")
+                    local inFlight = (pluginState.inFlightRequests or 0) > 0
+                    local pastSoft = idle > STALE_RECONNECT_SECONDS
+                    local pastHard = idle > STALE_RESTART_HARD_CAP_SECONDS
+                    if pastSoft and (not inFlight or pastHard) then
+                        local suffix = (inFlight and pastHard) and " [hard cap, request still in flight]" or ""
+                        addLog("Stale connection: " .. idle .. "s since last heartbeat, scheduling restart" .. suffix)
                         pluginState.lastRequestTime = nil
                         pluginState.lastConnectedTime = nil
                         pluginState.needsFullRestart = true
@@ -491,7 +537,7 @@ end
 -- subsequent startServer() isn't blocked by its "Already running" guard,
 -- and signal any surviving monitor loop to exit. Reset IN PLACE (not a new
 -- table) so this module's pluginState and the old loop's closure keep
--- pointing at the same table â€” flipping running here is what stops it.
+-- pointing at the same table — flipping running here is what stops it.
 local function resetForReload()
     if not pluginState.running then return end
     addLog("Reload detected - resetting previous server instance")
@@ -524,6 +570,7 @@ local function resetForReload()
     pluginState.lastConnectedTime = nil
     pluginState.needsFullRestart = false
     pluginState.freshRestart = false
+    pluginState.inFlightRequests = 0
 end
 
 addLog("PluginInfoProvider loaded")
@@ -652,5 +699,3 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
 end
 
 return PluginInfoProvider
-
-

--- a/plugin/spec/PluginInfoProvider_spec.lua
+++ b/plugin/spec/PluginInfoProvider_spec.lua
@@ -16,6 +16,9 @@ local HANDLER_MODULES = {
 --   socketOps      -- array; "close"/"reconnect" calls on bound sockets land here
 --   stopLoopOnSleep -- flip running=false on the first LrTasks.sleep so the
 --                      monitor loop exits after a single tick
+--   capturedBinds  -- array; each LrSocket.bind opts table is appended, in
+--                      bind order (request socket first, then response), so
+--                      a test can invoke onConnected/onMessage/etc directly
 local function installStubs(prefs, asyncTasks, opts)
     opts = opts or {}
     helper.installImport({
@@ -48,7 +51,8 @@ local function installStubs(prefs, asyncTasks, opts)
             end,
         },
         LrSocket = {
-            bind = function()
+            bind = function(bindOpts)
+                if opts.capturedBinds then table.insert(opts.capturedBinds, bindOpts) end
                 return {
                     close = function()
                         if opts.socketOps then table.insert(opts.socketOps, "close") end
@@ -268,6 +272,64 @@ describe("PluginInfoProvider server task", function()
     end)
 end)
 
+
+describe("stale-connection follow-up fixes (PR #151 re-review)", function()
+    local realOpen
+    before_each(function()
+        _G.LightroomMCP_State = nil
+        realOpen = io.open
+        io.open = function(path, mode, ...)
+            if mode and mode:find("w", 1, true) then
+                return { write = function() end, close = function() end }
+            end
+            return realOpen(path, mode, ...)
+        end
+    end)
+    after_each(function()
+        io.open = realOpen
+    end)
+
+    it("clears a stale lastRequestTime on a fresh REQUEST connect so it doesn't leak into the new idle clock", function()
+        local binds = {}
+        installStubs(nil, nil, { runTask = true, stopLoopOnSleep = true, cleanups = {}, capturedBinds = binds })
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        -- Simulate a prior session's activity timestamp surviving past a
+        -- manual Stop/Start (or any reconnect) that happens long after it
+        -- sat idle. Without clearing it here, the monitor loop's very next
+        -- tick would see a huge idle value and restart immediately.
+        _G.LightroomMCP_State.lastRequestTime = os.time() - 999
+        binds[1].onConnected()
+
+        assert.is_nil(_G.LightroomMCP_State.lastRequestTime)
+        assert.is_not_nil(_G.LightroomMCP_State.lastConnectedTime)
+    end)
+
+    it("keeps a request counted in-flight until sendResponse actually completes, not just until the handler returns", function()
+        package.loaded.JSON = nil -- exercise the real encoder/decoder, not the empty stub
+        local binds = {}
+        installStubs(nil, nil, { runTask = true, stopLoopOnSleep = true, cleanups = {}, capturedBinds = binds })
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        local state = _G.LightroomMCP_State
+        state.sendConnected = true
+        state.responseSocket = {
+            send = function()
+                -- If inFlightRequests were decremented right after the
+                -- handler returns (the pre-fix behavior), the monitor loop
+                -- could see 0 in-flight and restart the server while this
+                -- send is still happening — defeating the blast-radius fix.
+                assert.are.equal(1, state.inFlightRequests)
+            end,
+        }
+
+        binds[1].onMessage(nil, '{"id":1,"action":"ping","hello":"' .. state.token .. '"}')
+
+        assert.are.equal(0, state.inFlightRequests)
+    end)
+end)
 
 describe("heartbeat / stale-connection blast radius (PR #151 review)", function()
     before_each(function()

--- a/plugin/spec/PluginInfoProvider_spec.lua
+++ b/plugin/spec/PluginInfoProvider_spec.lua
@@ -267,3 +267,64 @@ describe("PluginInfoProvider server task", function()
         assert.is_false(_G.LightroomMCP_State.responseNeedsReconnect)
     end)
 end)
+
+
+describe("heartbeat / stale-connection blast radius (PR #151 review)", function()
+    before_each(function()
+        _G.LightroomMCP_State = nil
+        installStubs()
+    end)
+
+    it("ping handler is a pure liveness no-op returning pong=true", function()
+        local mod = loadInfoProvider()
+        assert.are.same({ pong = true }, mod.handlePing({}))
+    end)
+
+    it("derives the soft/hard thresholds from the heartbeat interval", function()
+        local mod = loadInfoProvider()
+        assert.are.equal(30, mod.HEARTBEAT_INTERVAL_SECONDS)
+        assert.are.equal(90, mod.STALE_RECONNECT_SECONDS)
+        assert.are.equal(120, mod.STALE_RESTART_HARD_CAP_SECONDS)
+    end)
+
+    describe("shouldRestartForStaleConnection", function()
+        it("does not restart while idle is within the soft threshold", function()
+            local mod = loadInfoProvider()
+            local restart, suffix = mod.shouldRestartForStaleConnection(
+                89, 0, mod.STALE_RECONNECT_SECONDS, mod.STALE_RESTART_HARD_CAP_SECONDS)
+            assert.is_false(restart)
+            assert.are.equal("", suffix)
+        end)
+
+        it("restarts once idle passes the soft threshold with nothing in flight", function()
+            local mod = loadInfoProvider()
+            local restart, suffix = mod.shouldRestartForStaleConnection(
+                91, 0, mod.STALE_RECONNECT_SECONDS, mod.STALE_RESTART_HARD_CAP_SECONDS)
+            assert.is_true(restart)
+            assert.are.equal("", suffix)
+        end)
+
+        it("defers the restart past the soft threshold while a request is genuinely in flight (blast radius fix)", function()
+            local mod = loadInfoProvider()
+            local restart, suffix = mod.shouldRestartForStaleConnection(
+                91, 1, mod.STALE_RECONNECT_SECONDS, mod.STALE_RESTART_HARD_CAP_SECONDS)
+            assert.is_false(restart)
+            assert.are.equal("", suffix)
+        end)
+
+        it("still restarts past the hard cap even if a request is in flight, to bound the wait", function()
+            local mod = loadInfoProvider()
+            local restart, suffix = mod.shouldRestartForStaleConnection(
+                121, 1, mod.STALE_RECONNECT_SECONDS, mod.STALE_RESTART_HARD_CAP_SECONDS)
+            assert.is_true(restart)
+            assert.are.equal(" [hard cap, request still in flight]", suffix)
+        end)
+
+        it("treats exactly-at-threshold idle as not yet past it (strict greater-than)", function()
+            local mod = loadInfoProvider()
+            local restart = mod.shouldRestartForStaleConnection(
+                90, 0, mod.STALE_RECONNECT_SECONDS, mod.STALE_RESTART_HARD_CAP_SECONDS)
+            assert.is_false(restart)
+        end)
+    end)
+end)

--- a/server/src/heartbeat.ts
+++ b/server/src/heartbeat.ts
@@ -1,0 +1,33 @@
+// Extracted from index.ts so the ping-interval wiring can be unit tested in
+// isolation, without booting the real MCP server / sockets that main() sets
+// up. See tests/heartbeat.test.ts.
+//
+// Heartbeat: ping the plugin on this interval so it can tell a healthy-but-
+// idle session apart from a genuinely dead connection (issue #134 follow-up,
+// PR #151 review) instead of relying on a long fixed idle timer. The plugin
+// derives liveness from any inbound message -- ping included -- via its
+// existing lastRequestTime tracking, so this side doesn't need to react to a
+// missed pong itself; a failed/timed-out ping is only logged for visibility.
+
+export interface HeartbeatDispatcher {
+  call(action: string, params: unknown): Promise<unknown>;
+}
+
+/**
+ * Starts a fire-and-forget ping loop against the dispatcher and returns the
+ * timer handle so the caller can clearInterval() it (e.g. on shutdown).
+ * dispatcher.call() rejects on its own if the request socket is currently
+ * disconnected, so this is safe to run unconditionally regardless of
+ * connection state -- a failed ping is just logged via onError, never thrown.
+ */
+export function startHeartbeat(
+  dispatcher: HeartbeatDispatcher,
+  intervalMs: number,
+  onError: (err: Error) => void = (err) => console.error(`[heartbeat] ping failed: ${err.message}`),
+): NodeJS.Timeout {
+  return setInterval(() => {
+    dispatcher.call("ping", {}).catch((err: Error) => {
+      onError(err);
+    });
+  }, intervalMs);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -21,9 +21,20 @@ const REQUEST_TIMEOUT_MS = 30_000;
 // Batch export/import render files and can run for minutes; the default
 // timeout would report a spurious failure mid-export. See issue #128.
 const LONG_RUNNING_TIMEOUT_MS = 300_000;
+// Heartbeat: ping the plugin on this interval so it can tell a healthy-but-
+// idle session apart from a genuinely dead connection (issue #134 follow-up,
+// PR #151 review) instead of relying on a long fixed idle timer. The plugin
+// derives liveness from any inbound message -- ping included -- via its
+// existing lastRequestTime tracking, so this side doesn't need to react to a
+// missed pong itself; a failed/timed-out ping is only logged for visibility.
+// Keep this interval in sync with HEARTBEAT_INTERVAL_SECONDS in
+// PluginInfoProvider.lua.
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const PING_TIMEOUT_MS = 10_000;
 const ACTION_TIMEOUTS_MS: Record<string, number> = {
   export_photos: LONG_RUNNING_TIMEOUT_MS,
   import_photos: LONG_RUNNING_TIMEOUT_MS,
+  ping: PING_TIMEOUT_MS,
 };
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -76,6 +87,15 @@ async function main() {
   });
   requestSocket.connect();
   responseSocket.connect();
+
+  // Fire-and-forget heartbeat. dispatcher.call() rejects on its own if the
+  // request socket is currently disconnected, so this is safe to run
+  // unconditionally regardless of connection state.
+  setInterval(() => {
+    dispatcher.call("ping", {}).catch((err: Error) => {
+      console.error(`[heartbeat] ping failed: ${err.message}`);
+    });
+  }, HEARTBEAT_INTERVAL_MS);
 
   const server = createMcpServer({
     dispatcher,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,7 @@ import { requestPort, responsePort } from "./ports.js";
 import { createMcpServer } from "./create-server.js";
 import { parseCli, helpText } from "./cli.js";
 import { VERSION } from "./version.js";
+import { startHeartbeat } from "./heartbeat.js";
 import {
   ensurePluginInstalled,
   findBundledPlugin,
@@ -21,14 +22,8 @@ const REQUEST_TIMEOUT_MS = 30_000;
 // Batch export/import render files and can run for minutes; the default
 // timeout would report a spurious failure mid-export. See issue #128.
 const LONG_RUNNING_TIMEOUT_MS = 300_000;
-// Heartbeat: ping the plugin on this interval so it can tell a healthy-but-
-// idle session apart from a genuinely dead connection (issue #134 follow-up,
-// PR #151 review) instead of relying on a long fixed idle timer. The plugin
-// derives liveness from any inbound message -- ping included -- via its
-// existing lastRequestTime tracking, so this side doesn't need to react to a
-// missed pong itself; a failed/timed-out ping is only logged for visibility.
 // Keep this interval in sync with HEARTBEAT_INTERVAL_SECONDS in
-// PluginInfoProvider.lua.
+// PluginInfoProvider.lua. See heartbeat.ts for what this drives.
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const PING_TIMEOUT_MS = 10_000;
 const ACTION_TIMEOUTS_MS: Record<string, number> = {
@@ -88,14 +83,7 @@ async function main() {
   requestSocket.connect();
   responseSocket.connect();
 
-  // Fire-and-forget heartbeat. dispatcher.call() rejects on its own if the
-  // request socket is currently disconnected, so this is safe to run
-  // unconditionally regardless of connection state.
-  setInterval(() => {
-    dispatcher.call("ping", {}).catch((err: Error) => {
-      console.error(`[heartbeat] ping failed: ${err.message}`);
-    });
-  }, HEARTBEAT_INTERVAL_MS);
+  startHeartbeat(dispatcher, HEARTBEAT_INTERVAL_MS);
 
   const server = createMcpServer({
     dispatcher,

--- a/server/tests/heartbeat.test.ts
+++ b/server/tests/heartbeat.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { startHeartbeat, type HeartbeatDispatcher } from '../src/heartbeat.js';
+
+const okDispatcher = (): HeartbeatDispatcher => ({
+  call: jest.fn((_action: string, _params: unknown) => Promise.resolve({ pong: true })),
+});
+
+const failingDispatcher = (failure: Error): HeartbeatDispatcher => ({
+  call: jest.fn((_action: string, _params: unknown) => Promise.reject(failure)),
+});
+
+describe('startHeartbeat', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not ping before the interval elapses', () => {
+    const dispatcher = okDispatcher();
+    startHeartbeat(dispatcher, 30_000);
+
+    expect(dispatcher.call).not.toHaveBeenCalled();
+  });
+
+  it('pings once per interval with action "ping" and empty params', () => {
+    const dispatcher = okDispatcher();
+    startHeartbeat(dispatcher, 30_000);
+
+    jest.advanceTimersByTime(30_000);
+    expect(dispatcher.call).toHaveBeenCalledTimes(1);
+    expect(dispatcher.call).toHaveBeenCalledWith('ping', {});
+
+    jest.advanceTimersByTime(30_000);
+    expect(dispatcher.call).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(60_000);
+    expect(dispatcher.call).toHaveBeenCalledTimes(4);
+  });
+
+  it('logs via onError and does not throw when a ping is rejected', async () => {
+    const failure = new Error('timeout');
+    const dispatcher = failingDispatcher(failure);
+    const onError = jest.fn();
+    startHeartbeat(dispatcher, 30_000, onError);
+
+    expect(() => jest.advanceTimersByTime(30_000)).not.toThrow();
+    // Let the rejected promise's .catch handler run before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+
+  it('defaults onError to a console.error log line mentioning the failure', async () => {
+    const failure = new Error('socket dropped');
+    const dispatcher = failingDispatcher(failure);
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    startHeartbeat(dispatcher, 30_000);
+
+    jest.advanceTimersByTime(30_000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[heartbeat] ping failed: socket dropped'));
+    consoleSpy.mockRestore();
+  });
+
+  it('stops pinging once the returned timer is cleared', () => {
+    const dispatcher = okDispatcher();
+    const timer = startHeartbeat(dispatcher, 30_000);
+    clearInterval(timer);
+
+    jest.advanceTimersByTime(120_000);
+    expect(dispatcher.call).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

On Windows, `LrSocket` does not reliably fire `onClosed` when the remote TCP peer exits. After Claude Desktop restarts (killing the MCP server process), the plugin retains stale socket state and never accepts the new MCP server connection — every subsequent tool call times out with "Plugin response timeout (30s)" until Lightroom is restarted or the user manually stops and starts the server in Plug-in Manager.

Fixes #134.

Builds on the restart mechanism introduced in #135.

## Root cause

Both sockets use the plugin as the TCP server (LrSocket binds and listens); the MCP server is the client on both. When the MCP server process exits:

- The OS tears down both TCP connections.
- **Expected:** `onClosed` fires, plugin resets connected state, sockets re-enter listening mode, new MCP server connects normally.
- **Actual (Windows):** `onClosed` does **not** fire. Plugin keeps `receiveConnected = true` and `sendConnected = true`. The new MCP server completes the TCP handshake at the OS level (so its log shows `[request] connected`), but LrSocket never calls `accept()` on the new connection and `onConnected` never fires. All requests go unread; all tool calls time out.

## Fix

Three additions to `PluginInfoProvider.lua`:

### 1. Stale connection detection

Track `lastRequestTime` (updated in `consumeMessage`) and `lastConnectedTime` (updated in `onConnected`). The monitor loop checks: if `receiveConnected` is true but no message has arrived for `STALE_RECONNECT_SECONDS` (300 s), set `needsFullRestart = true`.

### 2. Full server restart

When `needsFullRestart` is set, an async task inlines `stopServer`'s effect (`pluginState.running = false`), sleeps 0.5 s, and calls `startServer()`. Closing the LrSocket sends RST to the stale MCP client. The MCP server's `PluginSocket` receives ECONNRESET, reconnects after 1 s, and `onConnected` fires correctly on the fresh socket.

> **Note:** `stopServer()` is declared after `startServer()` in this file and is not an upvalue inside `startServer()`. The async task inlines its key effect rather than calling it by name.

### 3. `freshRestart` flag to prevent response-side cycling

Without this flag, `REQUEST onConnected` sets `responseNeedsRebind = true`, causing an immediate gen=1 to gen=2 rebind. The MCP server's response socket gets ECONNRESET, reconnects, and any response sent during that window arrives after the 30 s MCP timeout (visible as `Response for unknown id` in the MCP server log).

When stale detection triggers the restart, `freshRestart = true` is set. `REQUEST onConnected` checks this flag: if set, it skips the rebind (the response socket is already fresh from the restart) and logs `REQUEST socket connected (post-restart)`. `resetForReload()` also clears `freshRestart` so a plugin reload does not inherit stale flag state.

## User-visible behaviour

- First tool call after Claude Desktop restarts still times out (stale window has not elapsed yet).
- Plugin auto-recovers after `STALE_RECONNECT_SECONDS` (5 minutes) of idle-while-connected.
- The MCP server reconnects automatically; subsequent tool calls succeed with no manual intervention.

## Log signature (fixed)

Plugin log after recovery:

```
[info] Stale connection: 301s idle, scheduling restart
[info] Restarting server (stale connection recovery)
[info] RESPONSE socket closed (gen=N)
[info] REQUEST socket closed (client disconnected)
[info] Starting LrSocket servers
[info] RESPONSE bound on 58764 gen=1
[info] RESPONSE socket connected
[info] REQUEST socket connected (post-restart)   <- no RESPONSE rebound follows
```

## Testing notes

- **Do not use a short `STALE_RECONNECT_SECONDS` for testing.** A threshold below ~60 s causes the stale detection to fire while the MCP server is still settling from the previous restart, producing a cascade of ECONNRESET events that can take minutes to clear and makes the fix appear broken when it is not.
- **Reload the plugin at most once before testing**, and wait at least 60 s after any reload before making a tool call.
- **Confirmed working test:** restart Claude Desktop, wait 5+ minutes, make a tool call. It succeeds immediately, and the plugin log shows the `post-restart` pattern above.

## Future work

A proper fix would replace the idle timer with a **heartbeat**: the MCP server sends a lightweight ping on connect and periodically; the plugin triggers a restart only when a heartbeat is missed. This gives near-instant stale detection without the 5-minute recovery window. The restart mechanism added here would be reused unchanged; only the detection logic would change.