### PR TITLE
ci: pin Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          node-version: '24.15.0'
           cache: npm
           cache-dependency-path: server/package-lock.json
 
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          node-version: '24.15.0'
 
       - name: Assert all version sources agree
         run: node scripts/bump-version.mjs --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '25'
+          node-version: '24.15.0'
           cache: npm
           cache-dependency-path: server/package-lock.json
 
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '25'
+          node-version: '24.15.0'
           cache: npm
           cache-dependency-path: server/package-lock.json
 
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '25'
+          node-version: '24.15.0'
           cache: npm
           cache-dependency-path: server/package-lock.json
 
@@ -200,7 +200,7 @@ jobs:
       - name: Setup Node.js (npm registry)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '25'
+          node-version: '24.15.0'
           registry-url: 'https://registry.npmjs.org'
           cache: npm
           cache-dependency-path: server/package-lock.json

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "24"
+node = "24.15.0"
 bun = "1.3.14"
 lua = "5.5.0"
 # selene (Rust) is the Lua linter — see lua:lint. A native binary, so unlike

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Lua tooling: `mise install` provisions `lua` + `luarocks` + `selene`. `lua:test`
 
 ## CI
 
-- `.github/workflows/ci.yml` — build+test on ubuntu/macos/windows, Node 22.
+- `.github/workflows/ci.yml` — build+test on ubuntu/macos/windows, Node 24.15.0.
 - `.github/workflows/lua-lint.yml` — selene (via mise-action) on plugin changes.
 - Type check runs `npm run check` (`tsc --noEmit` on src + `tsconfig.test.json` on tests); do not break it.
 - Lint runs `npm run lint` (ESLint flat config, type-aware rules over src + tests); do not break it.


### PR DESCRIPTION
## Summary
- Pin Node to 24.15.0 in mise, CI, and release workflows
- Align release workflow with CI so npm trusted publishing does not pick unsupported Node/npm combinations
- Update stale CI documentation note

## Testing
- git diff --check
- verified no remaining floating Node 24/25 setup references in workflow/tooling config