### PR TITLE
Fix duplicate bridge socket ownership

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import { createMcpServer } from "./create-server.js";
 import { parseCli, helpText } from "./cli.js";
 import { VERSION } from "./version.js";
 import { startHeartbeat } from "./heartbeat.js";
+import { acquireInstanceLock } from "./instance-lock.js";
 import {
   ensurePluginInstalled,
   findBundledPlugin,
@@ -26,6 +27,7 @@ const LONG_RUNNING_TIMEOUT_MS = 300_000;
 // PluginInfoProvider.lua. See heartbeat.ts for what this drives.
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const PING_TIMEOUT_MS = 10_000;
+const RESPONSE_CONNECT_SETTLE_MS = 200;
 const ACTION_TIMEOUTS_MS: Record<string, number> = {
   export_photos: LONG_RUNNING_TIMEOUT_MS,
   import_photos: LONG_RUNNING_TIMEOUT_MS,
@@ -66,28 +68,62 @@ async function main() {
     process.exit(1);
   }
 
+  try {
+    acquireInstanceLock(REQUEST_PORT, RESPONSE_PORT);
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+
   ensurePluginInstalled(here, (m) => console.error(m));
 
-  const requestSocket = new PluginSocket({ port: REQUEST_PORT, label: "request" });
+  let requestSocket: PluginSocket;
+  let responseSocket: PluginSocket | null = null;
+  let responseConnectTimer: NodeJS.Timeout | null = null;
   const dispatcher = new Dispatcher({
     send: (line) => requestSocket.send(line),
     getToken: () => readToken(),
     timeoutMs: REQUEST_TIMEOUT_MS,
     actionTimeoutsMs: ACTION_TIMEOUTS_MS,
   });
-  const responseSocket = new PluginSocket({
-    port: RESPONSE_PORT,
-    label: "response",
-    onLine: (line) => dispatcher.handleResponseLine(line),
+  const startResponseSocket = () => {
+    if (responseSocket || !requestSocket.isConnected()) return;
+    responseSocket = new PluginSocket({
+      port: RESPONSE_PORT,
+      label: "response",
+      onLine: (line) => dispatcher.handleResponseLine(line),
+    });
+    responseSocket.connect();
+  };
+  const stopResponseSocket = () => {
+    if (responseConnectTimer) {
+      clearTimeout(responseConnectTimer);
+      responseConnectTimer = null;
+    }
+    responseSocket?.stop();
+    responseSocket = null;
+  };
+  requestSocket = new PluginSocket({
+    port: REQUEST_PORT,
+    label: "request",
+    onConnect: () => {
+      if (responseConnectTimer) clearTimeout(responseConnectTimer);
+      responseConnectTimer = setTimeout(() => {
+        responseConnectTimer = null;
+        startResponseSocket();
+      }, RESPONSE_CONNECT_SETTLE_MS);
+    },
+    onDisconnect: () => {
+      stopResponseSocket();
+    },
   });
   requestSocket.connect();
-  responseSocket.connect();
 
   startHeartbeat(dispatcher, HEARTBEAT_INTERVAL_MS);
 
   const server = createMcpServer({
     dispatcher,
-    isReady: () => requestSocket.isConnected() && responseSocket.isConnected(),
+    isReady: () => requestSocket.isConnected() && (responseSocket?.isConnected() ?? false),
   });
 
   const transport = new StdioServerTransport();

--- a/server/src/instance-lock.ts
+++ b/server/src/instance-lock.ts
@@ -28,70 +28,60 @@ function readPid(pidFile: string): number | null {
 export function acquireInstanceLock(
   requestPort: number,
   responsePort: number,
-  baseDir = os.tmpdir(),
+  baseDir = path.join(os.homedir(), ".config", "lightroom-mcp"),
 ): InstanceLock {
-  const lockDir = path.join(baseDir, `lightroom-mcp-${requestPort}-${responsePort}.lock`);
-  const pidFile = path.join(lockDir, "pid");
-  const candidateDir = `${lockDir}.${process.pid}.${Date.now()}.${Math.random()
-    .toString(16)
-    .slice(2)}.new`;
+  fs.mkdirSync(baseDir, { recursive: true, mode: 0o700 });
+  const lockFile = path.join(baseDir, `bridge-${requestPort}-${responsePort}.lock`);
 
-  fs.mkdirSync(candidateDir);
-  fs.writeFileSync(path.join(candidateDir, "pid"), `${process.pid}\n`, { encoding: "utf8" });
-
-  let acquired = false;
-  while (!acquired) {
+  while (true) {
+    let fd: number | null = null;
     try {
-      fs.renameSync(candidateDir, lockDir);
-      acquired = true;
+      fd = fs.openSync(lockFile, "wx", 0o600);
+      fs.writeFileSync(fd, `${process.pid}\n`, { encoding: "utf8" });
       break;
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
-      if (code !== "EEXIST" && code !== "ENOTEMPTY") {
-        fs.rmSync(candidateDir, { recursive: true, force: true });
+      if (code !== "EEXIST") {
         throw err;
       }
-    }
 
-    const existingPid = readPid(pidFile);
-    if (existingPid && pidIsAlive(existingPid)) {
-      fs.rmSync(candidateDir, { recursive: true, force: true });
-      throw new Error(
-        `Another Lightroom MCP bridge is already running for ports ${requestPort}/${responsePort} (pid ${existingPid})`,
-      );
-    }
-
-    const staleDir = `${lockDir}.stale.${process.pid}.${Date.now()}.${Math.random()
-      .toString(16)
-      .slice(2)}`;
-    try {
-      fs.renameSync(lockDir, staleDir);
-      fs.rmSync(staleDir, { recursive: true, force: true });
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== "ENOENT" && code !== "EEXIST") {
-        fs.rmSync(candidateDir, { recursive: true, force: true });
-        throw err;
+      const existingPid = readPid(lockFile);
+      if (existingPid && pidIsAlive(existingPid)) {
+        throw new Error(
+          `Another Lightroom MCP bridge is already running for ports ${requestPort}/${responsePort} (pid ${existingPid})`,
+        );
       }
+
+      try {
+        fs.unlinkSync(lockFile);
+      } catch (unlinkErr) {
+        if ((unlinkErr as NodeJS.ErrnoException).code !== "ENOENT") throw unlinkErr;
+      }
+    } finally {
+      if (fd !== null) fs.closeSync(fd);
     }
   }
 
   let released = false;
+  const exitHandler = () => release();
+  const signalHandler = () => {
+    release();
+    process.exit(0);
+  };
   const release = () => {
     if (released) return;
     released = true;
-    if (readPid(pidFile) === process.pid) {
-      fs.rmSync(lockDir, { recursive: true, force: true });
+    process.off("exit", exitHandler);
+    process.off("SIGINT", signalHandler);
+    process.off("SIGTERM", signalHandler);
+    if (readPid(lockFile) === process.pid) {
+      fs.unlinkSync(lockFile);
     }
   };
 
-  process.once("exit", release);
-  for (const signal of ["SIGINT", "SIGTERM"] as const) {
-    process.once(signal, () => {
-      release();
-      process.exit(0);
-    });
-  }
+  process.once("exit", exitHandler);
+  process.once("SIGINT", signalHandler);
+  process.once("SIGTERM", signalHandler);
 
   return { release };
 }

--- a/server/src/instance-lock.ts
+++ b/server/src/instance-lock.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface InstanceLock {
+  release: () => void;
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function readPid(pidFile: string): number | null {
+  try {
+    const raw = fs.readFileSync(pidFile, "utf8").trim();
+    const parsed = Number(raw);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function acquireInstanceLock(
+  requestPort: number,
+  responsePort: number,
+  baseDir = os.tmpdir(),
+): InstanceLock {
+  const lockDir = path.join(baseDir, `lightroom-mcp-${requestPort}-${responsePort}.lock`);
+  const pidFile = path.join(lockDir, "pid");
+  const candidateDir = `${lockDir}.${process.pid}.${Date.now()}.${Math.random()
+    .toString(16)
+    .slice(2)}.new`;
+
+  fs.mkdirSync(candidateDir);
+  fs.writeFileSync(path.join(candidateDir, "pid"), `${process.pid}\n`, { encoding: "utf8" });
+
+  let acquired = false;
+  while (!acquired) {
+    try {
+      fs.renameSync(candidateDir, lockDir);
+      acquired = true;
+      break;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST" && code !== "ENOTEMPTY") {
+        fs.rmSync(candidateDir, { recursive: true, force: true });
+        throw err;
+      }
+    }
+
+    const existingPid = readPid(pidFile);
+    if (existingPid && pidIsAlive(existingPid)) {
+      fs.rmSync(candidateDir, { recursive: true, force: true });
+      throw new Error(
+        `Another Lightroom MCP bridge is already running for ports ${requestPort}/${responsePort} (pid ${existingPid})`,
+      );
+    }
+
+    const staleDir = `${lockDir}.stale.${process.pid}.${Date.now()}.${Math.random()
+      .toString(16)
+      .slice(2)}`;
+    try {
+      fs.renameSync(lockDir, staleDir);
+      fs.rmSync(staleDir, { recursive: true, force: true });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "EEXIST") {
+        fs.rmSync(candidateDir, { recursive: true, force: true });
+        throw err;
+      }
+    }
+  }
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    if (readPid(pidFile) === process.pid) {
+      fs.rmSync(lockDir, { recursive: true, force: true });
+    }
+  };
+
+  process.once("exit", release);
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      release();
+      process.exit(0);
+    });
+  }
+
+  return { release };
+}

--- a/server/src/plugin-socket.ts
+++ b/server/src/plugin-socket.ts
@@ -7,6 +7,7 @@ export interface PluginSocketOptions {
   reconnectDelayMs?: number;
   onLine?: (line: string) => void;
   onConnect?: () => void;
+  onDisconnect?: () => void;
   log?: (msg: string) => void;
 }
 
@@ -23,6 +24,7 @@ export class PluginSocket {
   private readonly reconnectDelayMs: number;
   private readonly onLine?: (line: string) => void;
   private readonly onConnect?: () => void;
+  private readonly onDisconnect?: () => void;
   private readonly log: (msg: string) => void;
 
   constructor(opts: PluginSocketOptions) {
@@ -32,6 +34,7 @@ export class PluginSocket {
     this.reconnectDelayMs = opts.reconnectDelayMs ?? 1000;
     this.onLine = opts.onLine;
     this.onConnect = opts.onConnect;
+    this.onDisconnect = opts.onDisconnect;
     this.log = opts.log ?? ((msg: string) => console.error(msg));
   }
 
@@ -70,6 +73,7 @@ export class PluginSocket {
       this.socket = null;
       this.buffer = "";
       if (wasConnected) this.log(`[${this.label}] disconnected, reconnecting`);
+      if (wasConnected) this.onDisconnect?.();
       this.scheduleReconnect();
     });
 

--- a/server/tests/instance-lock.test.ts
+++ b/server/tests/instance-lock.test.ts
@@ -38,12 +38,28 @@ describe("instance lock", () => {
 
   it("replaces a stale lock with a fully written live lock", () => {
     const dir = baseDir();
-    const lockDir = path.join(dir, "lightroom-mcp-58763-58764.lock");
-    fs.mkdirSync(lockDir);
-    fs.writeFileSync(path.join(lockDir, "pid"), "999999999\n");
+    const lockFile = path.join(dir, "bridge-58763-58764.lock");
+    fs.writeFileSync(lockFile, "999999999\n");
 
     locks.push(acquireInstanceLock(58763, 58764, dir));
 
-    expect(fs.readFileSync(path.join(lockDir, "pid"), "utf8")).toBe(`${process.pid}\n`);
+    expect(fs.readFileSync(lockFile, "utf8")).toBe(`${process.pid}\n`);
+  });
+
+  it("removes process handlers when released", () => {
+    const beforeExit = process.listenerCount("exit");
+    const beforeSigint = process.listenerCount("SIGINT");
+    const beforeSigterm = process.listenerCount("SIGTERM");
+
+    const lock = acquireInstanceLock(58763, 58764, baseDir());
+    expect(process.listenerCount("exit")).toBe(beforeExit + 1);
+    expect(process.listenerCount("SIGINT")).toBe(beforeSigint + 1);
+    expect(process.listenerCount("SIGTERM")).toBe(beforeSigterm + 1);
+
+    lock.release();
+
+    expect(process.listenerCount("exit")).toBe(beforeExit);
+    expect(process.listenerCount("SIGINT")).toBe(beforeSigint);
+    expect(process.listenerCount("SIGTERM")).toBe(beforeSigterm);
   });
 });

--- a/server/tests/instance-lock.test.ts
+++ b/server/tests/instance-lock.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { acquireInstanceLock, type InstanceLock } from "../src/instance-lock.js";
+
+describe("instance lock", () => {
+  let tmpDir: string | null = null;
+  const locks: InstanceLock[] = [];
+
+  afterEach(() => {
+    while (locks.length > 0) {
+      locks.pop()?.release();
+    }
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
+  });
+
+  function baseDir(): string {
+    tmpDir ??= fs.mkdtempSync(path.join(os.tmpdir(), "lightroom-mcp-lock-test-"));
+    return tmpDir;
+  }
+
+  it("rejects a second live bridge for the same ports", () => {
+    locks.push(acquireInstanceLock(58763, 58764, baseDir()));
+
+    expect(() => acquireInstanceLock(58763, 58764, baseDir())).toThrow(
+      /Another Lightroom MCP bridge is already running/,
+    );
+  });
+
+  it("allows different port pairs to run independently", () => {
+    locks.push(acquireInstanceLock(58763, 58764, baseDir()));
+    locks.push(acquireInstanceLock(58765, 58766, baseDir()));
+  });
+
+  it("replaces a stale lock with a fully written live lock", () => {
+    const dir = baseDir();
+    const lockDir = path.join(dir, "lightroom-mcp-58763-58764.lock");
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(path.join(lockDir, "pid"), "999999999\n");
+
+    locks.push(acquireInstanceLock(58763, 58764, dir));
+
+    expect(fs.readFileSync(path.join(lockDir, "pid"), "utf8")).toBe(`${process.pid}\n`);
+  });
+});

--- a/server/tests/instance-lock.test.ts
+++ b/server/tests/instance-lock.test.ts
@@ -46,6 +46,28 @@ describe("instance lock", () => {
     expect(fs.readFileSync(lockFile, "utf8")).toBe(`${process.pid}\n`);
   });
 
+  it("replaces a malformed stale lock", () => {
+    const dir = baseDir();
+    const lockFile = path.join(dir, "bridge-58763-58764.lock");
+    fs.writeFileSync(lockFile, "not-a-pid\n");
+
+    locks.push(acquireInstanceLock(58763, 58764, dir));
+
+    expect(fs.readFileSync(lockFile, "utf8")).toBe(`${process.pid}\n`);
+  });
+
+  it("allows release after the lock file is already gone", () => {
+    const dir = baseDir();
+    const lockFile = path.join(dir, "bridge-58763-58764.lock");
+    const lock = acquireInstanceLock(58763, 58764, dir);
+    fs.unlinkSync(lockFile);
+
+    lock.release();
+    lock.release();
+
+    expect(fs.existsSync(lockFile)).toBe(false);
+  });
+
   it("removes process handlers when released", () => {
     const beforeExit = process.listenerCount("exit");
     const beforeSigint = process.listenerCount("SIGINT");

--- a/server/tests/plugin-rebind.test.ts
+++ b/server/tests/plugin-rebind.test.ts
@@ -195,4 +195,75 @@ describe("plugin rebind cycle (issue #110)", () => {
     },
     60_000,
   );
+
+  it(
+    "reproduces the unguarded split-client response interception from issue #164",
+    async () => {
+      const [requestPort, responsePort] = await Promise.all([freePort(), freePort()]);
+      const handledActions: string[] = [];
+      const plugin = new FakePlugin({
+        requestPort,
+        responsePort,
+        token: TOKEN,
+        sendWaitMs: 500,
+        handler: (action: string) => {
+          handledActions.push(action);
+          return { echoed: action };
+        },
+      });
+      await plugin.start();
+
+      const requestA = new PluginSocket({
+        port: requestPort,
+        label: "request-a",
+        reconnectDelayMs: 50,
+        log: () => {},
+      });
+      const dispatcherA = new Dispatcher({
+        send: (line) => requestA.send(line),
+        getToken: () => TOKEN,
+        timeoutMs: 1_000,
+        log: () => {},
+      });
+
+      const responsesOnB: string[] = [];
+      const dispatcherB = new Dispatcher({
+        send: () => false,
+        getToken: () => TOKEN,
+        timeoutMs: 1_000,
+        log: () => {},
+      });
+      const responseB = new PluginSocket({
+        port: responsePort,
+        label: "response-b",
+        reconnectDelayMs: 50,
+        log: () => {},
+        onLine: (line) => {
+          responsesOnB.push(line);
+          dispatcherB.handleResponseLine(line);
+        },
+      });
+
+      harness = {
+        plugin,
+        request: requestA,
+        response: responseB,
+        dispatcher: dispatcherA,
+      };
+      requestA.connect();
+      await waitFor(() => requestA.isConnected(), 3_000, "request A connected");
+      await waitFor(
+        () => plugin.events.some((evt) => evt.kind === "response_rebound"),
+        3_000,
+        "response rebound after request A connected",
+      );
+      responseB.connect();
+      await waitFor(() => responseB.isConnected(), 3_000, "response B connected");
+
+      await expect(dispatcherA.call("get_selected_photos", {})).rejects.toThrow(/timeout/i);
+      expect(handledActions).toEqual(["get_selected_photos"]);
+      expect(responsesOnB).toHaveLength(1);
+    },
+    10_000,
+  );
 });


### PR DESCRIPTION
## Summary
- add a per-port bridge instance lock so duplicate helper processes exit before touching Lightroom sockets
- open the response socket only after the request connection has settled, and close it when request disconnects
- add regression coverage for the unguarded split-client response interception and instance-lock behavior

Fixes #164.

## Verification
- npm run check
- npm run lint
- npm run build
- npm test -- --runInBand

## Review
- Ran adversarial subagent review; fixed the surviving findings around stale-lock atomicity and weak split-client regression coverage.