### PR TITLE
fix(plugin): repair directory import (nil extension, non-recursive walk)

### DIFF
--- a/plugin/LightroomMCP.lrplugin/HandlerImport.lua
+++ b/plugin/LightroomMCP.lrplugin/HandlerImport.lua
@@ -1,6 +1,7 @@
 local LrApplication = import 'LrApplication'
 local LrTasks = import 'LrTasks'
 local LrFileUtils = import 'LrFileUtils'
+local LrPathUtils = import 'LrPathUtils'
 
 local Log = require 'Log'
 
@@ -27,9 +28,15 @@ function ImportHandler.importPhotos(args)
     -- needs no catalog access.
     local photosToImport = {}
     if sourceKind == 'directory' then
-        -- Import all photos from directory
-        for file in LrFileUtils.files(args.source_path) do
-            local ext = LrFileUtils.extension(file):lower()
+        -- Import all photos from directory, including nested subfolders.
+        -- LrFileUtils.files lists only the immediate directory, so a source
+        -- organized as shoot/roll subfolders (the common Lightroom layout)
+        -- enumerated nothing and failed with "No photos found to import".
+        for file in LrFileUtils.recursiveFiles(args.source_path) do
+            -- extension() is on LrPathUtils; LrFileUtils has no such field, so
+            -- the previous call was nil and raised "attempt to call field
+            -- 'extension' (a nil value)" on every directory import.
+            local ext = LrPathUtils.extension(file):lower()
             if ext == 'jpg' or ext == 'jpeg' or ext == 'png' or
                ext == 'tif' or ext == 'tiff' or ext == 'dng' or
                ext == 'cr2' or ext == 'nef' or ext == 'arw' then

--- a/plugin/spec/HandlerImport_spec.lua
+++ b/plugin/spec/HandlerImport_spec.lua
@@ -3,6 +3,13 @@ local helper = require 'spec_helper'
 -- Mirrors the real SDK: LrFileUtils.exists returns 'file' / 'directory' / false,
 -- and LrFileUtils.isDirectory is intentionally absent (nil on some Lightroom
 -- Classic runtimes -- issue #129).
+--
+-- Two omissions here are deliberate and load-bearing:
+--   * no `extension` -- that field lives on LrPathUtils, not LrFileUtils.
+--   * no `files`     -- the handler must walk nested subfolders via
+--                       recursiveFiles; a plain files() walk misses them.
+-- Providing either would let a regression to the wrong API pass green, which
+-- is precisely how both bugs shipped.
 local function fakeFileUtils(opts)
     return {
         exists = function(p)
@@ -10,7 +17,7 @@ local function fakeFileUtils(opts)
             if opts.exists and opts.exists[p] then return 'file' end
             return false
         end,
-        files = function(_)
+        recursiveFiles = function(_)
             local i = 0
             local list = opts.dirContents or {}
             return function()
@@ -18,6 +25,12 @@ local function fakeFileUtils(opts)
                 return list[i]
             end
         end,
+    }
+end
+
+-- extension() belongs to LrPathUtils in the real SDK.
+local function fakePathUtils()
+    return {
         extension = function(p) return p:match("%.([^.]+)$") or "" end,
     }
 end
@@ -29,6 +42,7 @@ local function setup(opts)
         LrLogger = helper.defaultLrLogger(),
         LrTasks = {},
         LrFileUtils = fakeFileUtils(opts.fs or {}),
+        LrPathUtils = fakePathUtils(),
     })
     package.loaded.HandlerImport = nil
     return catalog, require 'HandlerImport'
@@ -68,6 +82,29 @@ describe("HandlerImport.importPhotos", function()
         })
 
         local r = Handler.importPhotos({ source_path = "/dir" })
+        assert.are.equal(3, r.imported)
+    end)
+
+    it("imports photos nested in subfolders", function()
+        -- Photo libraries are organized as shoot/roll subfolders, so the source
+        -- directory usually holds no photos itself. An immediate-directory walk
+        -- enumerated nothing and failed with "No photos found to import"; the
+        -- walk has to recurse.
+        local _, Handler = setup({
+            fs = {
+                exists = { ["/dir"] = true },
+                directories = { ["/dir"] = true },
+                dirContents = {
+                    "/dir/roll1/a.jpg",
+                    "/dir/roll1/scans/b.tif",
+                    "/dir/roll2/c.arw",
+                },
+            },
+        })
+
+        local r = Handler.importPhotos({ source_path = "/dir" })
+
+        assert.is_true(r.success)
         assert.are.equal(3, r.imported)
     end)
 


### PR DESCRIPTION
## The bug

`import_photos` fails on **every** directory source, in two independent ways:

**1. `LrFileUtils.extension` does not exist.** `extension()` lives on `LrPathUtils`, so the call is nil:

```
[string "HandlerImport.lua"]:32: attempt to call field 'extension' (a nil value)
```

**2. `LrFileUtils.files` is not recursive.** It lists only the immediate directory. Photo libraries are organized as shoot/roll subfolders, so the source directory typically holds no photos itself:

```
[string "HandlerImport.lua"]:45: No photos found to import
```

Both reproduced against a real catalog (Lightroom Classic 15.4.1) importing a 35mm scan library laid out as `35mm/<roll>/*.jpg` and a RAW shoot tree.

## The fix

- `LrFileUtils.files` → `LrFileUtils.recursiveFiles`
- `LrFileUtils.extension` → `LrPathUtils.extension`, plus the missing `import 'LrPathUtils'` (the plugin already imports it in `PluginInfoProvider.lua`, so this is consistent with the codebase)

## Why CI was green

`HandlerImport_spec.lua`'s `fakeFileUtils` **invented an `extension()` field the real SDK doesn't have**, so the handler's wrong call resolved fine under test. The fake also supplied `files()`, so the non-recursive walk looked correct too. The double was mirroring the bug rather than the SDK.

This PR corrects the double to match the real SDK:

- `extension()` moves to a new `LrPathUtils` fake
- `files()` is dropped from the `LrFileUtils` fake

Both omissions are load-bearing — a regression to either wrong API now fails loudly instead of passing. Adds a regression test covering the nested-subfolder case.

## Not included

The accepted-extension list still omits `cr3`, `raf`, `orf`, `rw2`. Happy to add that in a follow-up — kept this PR scoped to the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
