### PR TITLE
fix: shut down the bridge when the MCP client closes stdin

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -128,6 +128,21 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  // Exit when the MCP client goes away. Signal handlers never fire when the
+  // parent dies without signaling (typical on Windows), and the live plugin
+  // sockets plus the heartbeat interval keep the event loop alive — the
+  // orphaned bridge then holds both the single-client plugin connection and
+  // the instance lock, so every future bridge instance fails with "Another
+  // Lightroom MCP bridge is already running". Stdin EOF is the one reliable
+  // cross-platform signal that the client is gone.
+  const exitOnClientGone = (reason: string) => () => {
+    console.error(`Shutting down: ${reason}`);
+    process.exit(0);
+  };
+  process.stdin.once("end", exitOnClientGone("stdin ended (client exited)"));
+  process.stdin.once("close", exitOnClientGone("stdin closed (client exited)"));
+
   console.error(`Lightroom MCP server v${VERSION} running on stdio`);
   console.error(`Connecting to plugin: request :${REQUEST_PORT}, response :${RESPONSE_PORT}`);
   console.error(`Token file: ${tokenFilePath()}`);


### PR DESCRIPTION
# fix: shut down the bridge when the MCP client closes stdin

## Problem

When the MCP client (e.g. a Claude Code session) dies without signaling its children — the typical case on Windows, where no SIGTERM/SIGINT is delivered to the detached `node` process — the bridge keeps running forever: the live plugin sockets and the heartbeat interval keep the event loop alive.

The orphaned bridge then:

1. holds the single-client plugin connection (ports 58763/58764), and
2. holds the instance lock, so every new bridge instance exits immediately with `Another Lightroom MCP bridge is already running for ports 58763/58764 (pid …)`.

From the user's perspective every reconnect attempt fails even though Lightroom and the plugin are running fine. The only fix is manually finding and killing the orphaned `node.exe`.

**Repro (Windows, Claude Code):**
1. Start LR Classic + plugin server, start a Claude Code session with the bridge configured — tools work.
2. Kill/restart the session (the npx cmd-shim chain leaves the node child alive).
3. `netstat -ano | findstr 5876` → orphaned node holds ESTABLISHED connections to the plugin.
4. New session → MCP server fails on the instance lock → no tools, reconnect fails.

## Fix

Exit when stdin reaches EOF — the one reliable cross-platform signal that the client is gone (standard behavior for stdio MCP servers). `process.exit` triggers the existing `exit` handler in `instance-lock.ts`, so the lock file is released for the next instance; sockets die with the process.

## Verification

- `npm run check` and `npm test` pass (150/150).
- Manual: spawn `dist/index.js` with piped stdio (bogus ports), close stdin → process exits with code 0 and logs `Shutting down: stdin ended (client exited)`. Before this change it runs indefinitely.
- Field-tested: this exact orphan scenario was hit and diagnosed in production use on Windows 11 / LR Classic 14 / Claude Code.
