### PR TITLE
fix(plugin): stop background tasks fast on quit

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -278,6 +278,7 @@ Repo layout:
 
 - **`failed to open localhost:58763` after Reload Plug-in** — old async task still owns the port. Quit Lightroom (Cmd+Q on macOS / Alt+F4 on Windows) and reopen.
 - **Plugin not connected** — the server now self-restarts after a Reload Plug-in that tore down a running instance. If it's still stopped, click **Start Server** in Plug-in Manager; it reconnects within ~1s.
+- **Lightroom hangs on "performing shutdown tasks" when quitting** — the plugin now stops its background loop and drops both sockets as soon as Lightroom starts to quit, instead of reconnecting or waiting out a pending response. A handler that is already running (a large search, export, import, or preset apply) must still finish before Lightroom can quit.
 - **Timeout errors** — handler may be scanning a large catalog without filters; add `rating`, `filename`, `keywords`, or date filters to narrow.
 - **macOS "cannot be opened because the developer cannot be verified"** (binary path) — `xattr -d com.apple.quarantine /path/to/binary`. Or right-click → Open the first time.
 - **Windows SmartScreen blocks the .exe** — More info → Run anyway.

--- a/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginInfoProvider.lua
@@ -56,6 +56,7 @@ end
 if not _G.LightroomMCP_State then
     _G.LightroomMCP_State = {
         running = false,
+        shuttingDown = false,
         requestSocket = nil,
         responseSocket = nil,
         sendConnected = false,
@@ -73,6 +74,10 @@ if not _G.LightroomMCP_State then
 end
 
 local pluginState = _G.LightroomMCP_State
+
+local function shutdownRequested()
+    return pluginState.shuttingDown == true
+end
 
 local function tokenDir()
     return LrPathUtils.child(LrPathUtils.getStandardFilePath("home"), ".config")
@@ -190,9 +195,17 @@ local function shouldRestartForStaleConnection(idle, inFlightRequests, softSecon
 end
 
 local function sendResponse(response)
+    if shutdownRequested() then
+        addLog("Drop response (shutting down) id=" .. tostring(response.id))
+        return
+    end
     local waited = 0
     local selfHealRequested = false
     while not pluginState.sendConnected and waited < SEND_WAIT_SECONDS do
+        if shutdownRequested() then
+            addLog("Drop response (shutting down) id=" .. tostring(response.id))
+            return
+        end
         if not selfHealRequested and waited >= SEND_REBIND_TRIGGER_SECONDS then
             addLog("sendResponse stalled " .. SEND_REBIND_TRIGGER_SECONDS .. "s, requesting rebind id=" .. tostring(response.id))
             pluginState.responseNeedsRebind = true
@@ -215,6 +228,7 @@ local function sendResponse(response)
 end
 
 local function dispatchAction(request)
+    if shutdownRequested() then return end
     local id = request.id
     local action = request.action
     local params = request.params or {}
@@ -285,6 +299,10 @@ local function consumeMessage(message)
 end
 
 local function startServer()
+    if shutdownRequested() then
+        addLog("Start ignored (shutting down)")
+        return
+    end
     if pluginState.running then
         addLog("Already running")
         return
@@ -376,6 +394,7 @@ local function startServer()
                     end
                 end,
                 onMessage = function(_, message)
+                    if shutdownRequested() then return end
                     local request = consumeMessage(message)
                     if request then
                         LrTasks.startAsyncTask(function()
@@ -466,7 +485,7 @@ local function startServer()
         pluginState.responseSocket = bindResponse(pluginState.responseGen)
         addLog("RESPONSE bound on " .. responsePort .. " gen=" .. pluginState.responseGen)
 
-        while pluginState.running do
+        while pluginState.running and not shutdownRequested() do
             if pluginState.requestNeedsReconnect and pluginState.requestSocket then
                 pluginState.requestNeedsReconnect = false
                 pluginState.requestSocket:reconnect()
@@ -492,6 +511,7 @@ local function startServer()
                 -- again. The actual server-side reconnect takes ~1s, so
                 -- 100ms here doesn't meaningfully delay recovery.
                 LrTasks.sleep(0.1)
+                if shutdownRequested() then break end
                 pluginState.responseSocket = bindResponse(newGen)
                 pluginState.responseNeedsRebind = false
                 pluginState.responseNeedsReconnect = false
@@ -545,6 +565,11 @@ local function startServer()
     end)
 end
 
+local function startServerFromPanel()
+    pluginState.shuttingDown = false
+    startServer()
+end
+
 local function stopServer()
     if not pluginState.running then
         addLog("Not running")
@@ -563,6 +588,7 @@ end
 -- table) so this module's pluginState and the old loop's closure keep
 -- pointing at the same table — flipping running here is what stops it.
 local function resetForReload()
+    pluginState.shuttingDown = false
     if not pluginState.running then return end
     addLog("Reload detected - resetting previous server instance")
     pluginState.running = false
@@ -597,11 +623,40 @@ local function resetForReload()
     pluginState.inFlightRequests = 0
 end
 
+local function shutdown()
+    if not pluginState.running and not pluginState.requestSocket
+        and not pluginState.responseSocket then
+        pluginState.shuttingDown = true
+        return
+    end
+    addLog("Shutdown requested - stopping LrSocket servers")
+    pluginState.shuttingDown = true
+    pluginState.running = false
+    pluginState.requestNeedsReconnect = false
+    pluginState.responseNeedsRebind = false
+    pluginState.responseNeedsReconnect = false
+    pluginState.needsFullRestart = false
+    pluginState.freshRestart = false
+    if pluginState.requestSocket then
+        pcall(function() pluginState.requestSocket:close() end)
+    end
+    if pluginState.responseSocket then
+        pcall(function() pluginState.responseSocket:close() end)
+    end
+    pluginState.requestSocket = nil
+    pluginState.responseSocket = nil
+    pluginState.sendConnected = false
+    pluginState.receiveConnected = false
+    pluginState.token = nil
+end
+
 addLog("PluginInfoProvider loaded")
 
 local PluginInfoProvider = {
     startServer = startServer,
+    startServerFromPanel = startServerFromPanel,
     stopServer = stopServer,
+    shutdown = shutdown,
     resetForReload = resetForReload,
     -- Exposed for PluginInfoProvider_spec.lua only; not used elsewhere in the plugin.
     shouldRestartForStaleConnection = shouldRestartForStaleConnection,
@@ -699,7 +754,7 @@ function PluginInfoProvider.sectionsForTopOfDialog(f, propertyTable)
                         if pluginState.running then
                             stopServer()
                         else
-                            startServer()
+                            startServerFromPanel()
                         end
                     end,
                 },

--- a/plugin/LightroomMCP.lrplugin/PluginShutdown.lua
+++ b/plugin/LightroomMCP.lrplugin/PluginShutdown.lua
@@ -1,7 +1,7 @@
--- Called when Lightroom is shutting down. Tear down sockets cleanly so
--- ports are released before Lr exits.
-local state = _G.LightroomMCP_State
-if state then
+local function tearDownSharedState()
+    local state = _G.LightroomMCP_State
+    if not state then return end
+    state.shuttingDown = true
     state.running = false
     if state.requestSocket then
         pcall(function() state.requestSocket:close() end)
@@ -9,4 +9,16 @@ if state then
     if state.responseSocket then
         pcall(function() state.responseSocket:close() end)
     end
+    state.requestSocket = nil
+    state.responseSocket = nil
+    state.sendConnected = false
+    state.receiveConnected = false
+    state.token = nil
+end
+
+local ok, PluginInfoProvider = pcall(require, 'PluginInfoProvider')
+if ok and type(PluginInfoProvider) == "table" and type(PluginInfoProvider.shutdown) == "function" then
+    PluginInfoProvider.shutdown()
+else
+    tearDownSharedState()
 end

--- a/plugin/spec/PluginInfoProvider_spec.lua
+++ b/plugin/spec/PluginInfoProvider_spec.lua
@@ -19,6 +19,8 @@ local HANDLER_MODULES = {
 --   capturedBinds  -- array; each LrSocket.bind opts table is appended, in
 --                      bind order (request socket first, then response), so
 --                      a test can invoke onConnected/onMessage/etc directly
+--   onSleep        -- called with the shared state on each LrTasks.sleep, so a
+--                      test can flip flags between monitor-loop ticks
 local function installStubs(prefs, asyncTasks, opts)
     opts = opts or {}
     helper.installImport({
@@ -34,6 +36,7 @@ local function installStubs(prefs, asyncTasks, opts)
                 if opts.stopLoopOnSleep and _G.LightroomMCP_State then
                     _G.LightroomMCP_State.running = false
                 end
+                if opts.onSleep then opts.onSleep(_G.LightroomMCP_State) end
             end,
             pcall = pcall,
         },
@@ -388,5 +391,289 @@ describe("heartbeat / stale-connection blast radius (PR #151 review)", function(
                 90, 0, mod.STALE_RECONNECT_SECONDS, mod.STALE_RESTART_HARD_CAP_SECONDS)
             assert.is_false(restart)
         end)
+    end)
+end)
+
+describe("cooperative shutdown at Lightroom quit (issue 195)", function()
+    local realOpen
+    before_each(function()
+        _G.LightroomMCP_State = nil
+        realOpen = io.open
+        io.open = function(path, mode, ...)
+            if mode and mode:find("w", 1, true) then
+                return { write = function() end, close = function() end }
+            end
+            return realOpen(path, mode, ...)
+        end
+    end)
+    after_each(function()
+        io.open = realOpen
+        package.preload.PluginInfoProvider = nil
+    end)
+
+    local function requestFor(state, action)
+        return '{"id":1,"action":"' .. action .. '","hello":"' .. state.token .. '"}'
+    end
+
+    it("closes both sockets and clears connection state", function()
+        local ops = {}
+        installStubs(nil, nil, { runTask = true, stopLoopOnSleep = true, cleanups = {}, socketOps = ops })
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        mod.shutdown()
+
+        local state = _G.LightroomMCP_State
+        assert.is_true(state.shuttingDown)
+        assert.is_false(state.running)
+        assert.is_nil(state.requestSocket)
+        assert.is_nil(state.responseSocket)
+        assert.is_false(state.sendConnected)
+        assert.is_false(state.receiveConnected)
+        assert.is_nil(state.token)
+        assert.are.same({ "close", "close" }, ops)
+    end)
+
+    it("is a cheap no-op when the server never started", function()
+        local ops = {}
+        installStubs(nil, nil, { socketOps = ops })
+        local mod = loadInfoProvider()
+
+        assert.has_no.errors(function() mod.shutdown() end)
+        assert.are.same({}, ops)
+        assert.is_true(_G.LightroomMCP_State.shuttingDown)
+    end)
+
+    it("leaves the monitor loop on the first tick after quit begins", function()
+        local ticks = 0
+        installStubs(nil, {}, {
+            runTask = true,
+            cleanups = {},
+            onSleep = function(state)
+                ticks = ticks + 1
+                if ticks == 1 then
+                    state.shuttingDown = true
+                else
+                    state.running = false
+                end
+            end,
+        })
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+
+        assert.are.equal(1, ticks)
+    end)
+
+    it("does not bind a new response listener when quit lands inside the rebind yield", function()
+        local binds = {}
+        local ticks = 0
+        installStubs(nil, {}, {
+            runTask = true,
+            cleanups = {},
+            capturedBinds = binds,
+            onSleep = function(state)
+                ticks = ticks + 1
+                if ticks == 1 then
+                    state.responseNeedsRebind = true
+                elseif ticks == 2 then
+                    state.shuttingDown = true
+                else
+                    state.running = false
+                end
+            end,
+        })
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+
+        assert.is_table(binds[2])
+        assert.is_nil(binds[3])
+    end)
+
+    it("queues no dispatch task for a message that arrives during quit", function()
+        local binds, asyncTasks = {}, {}
+        installStubs(nil, asyncTasks, {
+            runTask = true, stopLoopOnSleep = true, cleanups = {}, capturedBinds = binds,
+        })
+        package.loaded.JSON = nil
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        local state = _G.LightroomMCP_State
+        state.shuttingDown = true
+        binds[1].onMessage(nil, requestFor(state, "ping"))
+
+        assert.is_nil(asyncTasks[1])
+    end)
+
+    it("does not run a handler whose dispatch task was queued before quit", function()
+        local binds, asyncTasks = {}, {}
+        local handlerCalls = 0
+        installStubs(nil, asyncTasks, {
+            runTask = true, stopLoopOnSleep = true, cleanups = {}, capturedBinds = binds,
+        })
+        package.loaded.JSON = nil
+        package.loaded.HandlerSearch = {
+            searchPhotos = function()
+                handlerCalls = handlerCalls + 1
+                return { photos = {} }
+            end,
+        }
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        local state = _G.LightroomMCP_State
+        binds[1].onMessage(nil, requestFor(state, "search_photos"))
+        state.shuttingDown = true
+        asyncTasks[1]()
+
+        assert.are.equal(0, handlerCalls)
+    end)
+
+    it("drops the response of a handler that finished after quit began", function()
+        local binds, sent = {}, {}
+        installStubs(nil, nil, {
+            runTask = true, stopLoopOnSleep = true, cleanups = {}, capturedBinds = binds,
+        })
+        package.loaded.JSON = nil
+        package.loaded.HandlerSearch = {
+            searchPhotos = function()
+                _G.LightroomMCP_State.shuttingDown = true
+                return { photos = {} }
+            end,
+        }
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        local state = _G.LightroomMCP_State
+        state.sendConnected = true
+        state.responseSocket = { send = function() table.insert(sent, true) end }
+
+        binds[1].onMessage(nil, requestFor(state, "search_photos"))
+
+        assert.are.same({}, sent)
+    end)
+
+    it("stops waiting for the send socket as soon as quit begins", function()
+        local binds = {}
+        local waitSleeps = 0
+        local waiting = false
+        installStubs(nil, nil, {
+            runTask = true, stopLoopOnSleep = true, cleanups = {}, capturedBinds = binds,
+            onSleep = function(state)
+                if not waiting then return end
+                waitSleeps = waitSleeps + 1
+                if waitSleeps == 2 then state.shuttingDown = true end
+            end,
+        })
+        package.loaded.JSON = nil
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        local state = _G.LightroomMCP_State
+        state.sendConnected = false
+        waiting = true
+
+        binds[1].onMessage(nil, requestFor(state, "ping"))
+
+        assert.are.equal(2, waitSleeps)
+    end)
+
+    it("abandons a pending stale-connection restart", function()
+        local asyncTasks = {}
+        local ticks = 0
+        installStubs(nil, asyncTasks, {
+            runTask = true,
+            cleanups = {},
+            onSleep = function(state)
+                ticks = ticks + 1
+                if ticks == 1 then
+                    state.needsFullRestart = true
+                else
+                    state.running = false
+                end
+            end,
+        })
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        local instanceBefore = _G.LightroomMCP_State.instanceId
+        _G.LightroomMCP_State.shuttingDown = true
+        local pendingRestart = asyncTasks[1]
+        assert.is_function(pendingRestart)
+        pendingRestart()
+
+        assert.are.equal(instanceBefore, _G.LightroomMCP_State.instanceId)
+    end)
+
+    it("refuses an auto-start that wakes after quit began", function()
+        installStubs(nil, nil, { runTask = true, stopLoopOnSleep = true, cleanups = {} })
+        local mod = loadInfoProvider()
+
+        mod.shutdown()
+        mod.startServer()
+
+        assert.is_false(_G.LightroomMCP_State.running)
+        assert.is_nil(_G.LightroomMCP_State.token)
+    end)
+
+    it("lets the Plug-in Manager Start button supersede an earlier shutdown", function()
+        installStubs(nil, nil, { runTask = true, stopLoopOnSleep = true, cleanups = {} })
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        mod.shutdown()
+        mod.startServerFromPanel()
+
+        assert.is_false(_G.LightroomMCP_State.shuttingDown)
+        assert.is_not_nil(_G.LightroomMCP_State.token)
+    end)
+
+    it("clears the shutdown flag on reload so the fresh instance can bind", function()
+        installStubs(nil, nil, { runTask = true, stopLoopOnSleep = true, cleanups = {} })
+        local mod = loadInfoProvider()
+
+        mod.startServer()
+        mod.shutdown()
+        mod.resetForReload()
+        mod.startServer()
+
+        assert.is_false(_G.LightroomMCP_State.shuttingDown)
+        assert.is_not_nil(_G.LightroomMCP_State.token)
+    end)
+
+    it("PluginShutdown.lua tears the server down through the module", function()
+        local ops = {}
+        installStubs(nil, nil, { runTask = true, stopLoopOnSleep = true, cleanups = {}, socketOps = ops })
+        local mod = loadInfoProvider()
+        mod.startServer()
+
+        package.loaded.PluginShutdown = nil
+        require 'PluginShutdown'
+
+        assert.is_true(_G.LightroomMCP_State.shuttingDown)
+        assert.is_false(_G.LightroomMCP_State.running)
+        assert.are.same({ "close", "close" }, ops)
+    end)
+
+    it("PluginShutdown.lua still tears down when the module cannot be required", function()
+        local ops = {}
+        installStubs(nil, nil, { runTask = true, stopLoopOnSleep = true, cleanups = {}, socketOps = ops })
+        local mod = loadInfoProvider()
+        mod.startServer()
+
+        package.loaded.PluginInfoProvider = nil
+        package.preload.PluginInfoProvider = function() error("load failed") end
+        package.loaded.PluginShutdown = nil
+        require 'PluginShutdown'
+        package.preload.PluginInfoProvider = nil
+
+        assert.is_true(_G.LightroomMCP_State.shuttingDown)
+        assert.is_false(_G.LightroomMCP_State.running)
+        assert.is_nil(_G.LightroomMCP_State.requestSocket)
+        assert.is_nil(_G.LightroomMCP_State.responseSocket)
+        assert.is_nil(_G.LightroomMCP_State.token)
+        assert.are.same({ "close", "close" }, ops)
     end)
 end)


### PR DESCRIPTION
## Motivation

Closes #195.

Quitting Lightroom Classic with the plugin enabled shows "Lightroom MCP is performing shutdown tasks" for several seconds.

> Changelog: fix(plugin): stop background tasks fast on quit

Lightroom cannot kill plug-in tasks at quit. It can only wait for them, and it holds that dialog while it waits. The old `PluginShutdown.lua` set `running = false` and closed both sockets, but no other code path knew a quit had started, so three tasks kept Lightroom waiting:

- the monitor loop could rebind the response socket mid-tick, and the new `LrSocket` listener then held its 10 s no-client accept wait;
- `sendResponse` waited up to 25 s for `sendConnected` on a socket that was already closed;
- the stale-connection recovery task slept 0.5 s and then started a whole new server, sockets included.

## Implementation information

- New `shuttingDown` flag on the shared state, raised by `PluginInfoProvider.shutdown()`. Flags go down before the sockets close, so a task that wakes during teardown unwinds instead of rebinding.
- `PluginShutdown.lua` (wired to both `LrShutdownApp` and `LrShutdownPlugin`) calls that one function, and falls back to a direct teardown of `_G.LightroomMCP_State` if the module cannot be required at quit time.
- Guards on every path that can outlive the quit: the monitor loop condition, the rebind branch after its 0.1 s yield, `onMessage`, `dispatchAction`, both `sendResponse` waits, and `startServer` itself.
- `startServer()` now refuses while a shutdown is pending. This closes the race where `PluginInit`'s auto-start task, which sleeps 0.5 s before starting, wakes after the quit began and binds two fresh sockets.
- The Plug-in Manager Start button calls a new `startServerFromPanel()`, which clears the flag first, so an explicit click always wins. A reload clears it through `resetForReload()`.

## Supporting documentation

- Cooperative shutdown is the documented pattern: a plug-in cannot enumerate or kill its own tasks, so a shared flag that every long-running task polls is the only mechanism — [Adobe forum](https://community.adobe.com/t5/lightroom-classic-discussions/lightroom-sdk-listing-and-killing-background-tasks/td-p/13228352).
- MIDI2LR, the reference for this plugin's dual-port transport, hit the same dialog.
- README troubleshooting entry added.

### Testing

- 13 busted tests in `PluginInfoProvider_spec.lua` cover the shutdown path. Each guard has a test that sets the flag at the one point only that guard can observe.
- Mutation-tested: deleting any one of the 11 guards or flag writes turns the suite red. Before this test pass, 10 of those deletions stayed green.
- `npm run check`, `npm run lint`, `mise run build`, Jest (161), `selene`, `busted` (142): all green.
- Not yet verified against a live Lightroom quit. Behaviour under a real `LrSocket` teardown is reasoned from the SDK, not measured.

https://claude.ai/code/session_017cjJRz6iqU1EuZxjCg8jnD
